### PR TITLE
Improve commit parsing for prefixed colons

### DIFF
--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -69,7 +69,7 @@ module Fastlane
         splitted.each do |line|
           # conventional commits are in format
           # type: subject (fix: app crash - for example)
-          type = line.split(":")[0]
+          type = line.split(":").reject(&:empty?)[0]
           release = releases[type.to_sym]
 
           if release == "patch"


### PR DESCRIPTION
Removes blank elements when splitting on colon to support commit messages with a prefixed colon supported by Bitbucket and Github. This allows the semantic release plugin to support https://gitmoji.carloscuesta.me/ out of the box while still supporting the conventional commits.