### PR TITLE
fix: use refs/tags for extracting commit hash from tag name

### DIFF
--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -25,7 +25,7 @@ module Fastlane
       end
 
       def self.get_last_tag_hash(params)
-        command = "git rev-list -n 1 #{params[:tag_name]}"
+        command = "git rev-list -n 1 refs/tags/#{params[:tag_name]}"
         Actions.sh(command, log: false).chomp
       end
 


### PR DESCRIPTION
We follow git branching model that roughly follows that of nvie's [git-flow](http://nvie.com/posts/a-successful-git-branching-model/).

Our release branches are named in a SemVer format, e.g. v3.1.0

`analyze_commits` action fails on these release branches since tags and branch names follow same format and the output for `git rev-list -n 1 #{tag_name}` is:

```
warning: refname '#{tag_name}' is ambiguous.
#{commit_hash}
```

instead of just commit hash.