### PR TITLE
fix: heading would not render correctly due lack of extra space

### DIFF
--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -48,7 +48,7 @@ module Fastlane
         title += " #{params[:title]}" if params[:title]
 
         # Begining of release notes
-        result = "##{title} (#{Date.today})"
+        result = "# #{title} (#{Date.today})"
         result += "\n"
 
         params[:order].each do |type|

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -23,7 +23,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "#1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n\n### Documentation\n- sub ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n\n### Documentation\n- sub ([short_hash](/long_hash))\n"
 
       expect(execute_lane_test).to eq(result)
     end
@@ -35,7 +35,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "#1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))\n"
 
       expect(execute_lane_test).to eq(result)
     end
@@ -47,7 +47,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "#1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n"
 
       expect(execute_lane_test).to eq(result)
     end
@@ -61,7 +61,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "#1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n\n### Rest work\n- Custom Merge... ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n\n### Rest work\n- Custom Merge... ([short_hash](/long_hash))\n"
 
       expect(execute_lane_test).to eq(result)
     end


### PR DESCRIPTION
Hey, thanks for this plugin!

This fixes the issue where Github wouldn't render the changelog correctly due to it being in the format of:

```md
##1.0.0 - Title
```

instead of: 

```md
# 1.0.0 - Title
```

Closes #6 