### PR TITLE
Plaintext format and new options for changelogs, plus refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ It provides these variables in `lane_context`.
 
 <img src="https://raw.githubusercontent.com/xotahal/fastlane-plugin-semantic_release/master/docs/Analyze.png" />
 
-### Questions
+## Tests
+
+To run the test suite (contained in `./spec`), call `bundle exec rake`
+
+## Questions
 
 If you need anything ping us on [twitter](http://bit.ly/t-xotahal).
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ It provides these variables in `lane_context`.
 ['RELEASE_NEXT_VERSION', 'Next version string in format (major.minor.patch)'],
 ```
 
+And you can access these like this:
+
 `next_version = lane_context[SharedValues::RELEASE_NEXT_VERSION]`
 
 <img src="https://raw.githubusercontent.com/xotahal/fastlane-plugin-semantic_release/master/docs/Analyze.png" />

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Available parameters:
 - `format: 'slack|markdown'` - defaults to `markdown` and formats the changelog for the destination you need
 - `title: 'My Title'` - is appended to the release notes title, "1.1.8 My Title (YYYY-MM-DD)"
 - `display_title: true|false` (defaults to true) - allows you to hide the entire first line of the changelog
+- `display_links: true|false` (defaults to true) - allows you to hide links to commits from your changelog
 - `commit_url: 'https://github.com/username/repository/commit'` - prepended to the commit ID to build usable links
 - View other options by searching for `available_options` in `conventional_changelog.rb`
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Available parameters:
 
 - `format: 'slack|markdown'` - defaults to `markdown` and formats the changelog for the destination you need
 - `title: 'My Title'` - is appended to the release notes title, "1.1.8 My Title (YYYY-MM-DD)"
+- `display_title: true|false` (defaults to true) - allows you to hide the entire first line of the changelog
 - `commit_url: 'https://github.com/username/repository/commit'` - prepended to the commit ID to build usable links
 - View other options by searching for `available_options` in `conventional_changelog.rb`
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Getting Started
 
-```bash
+```
 fastlane add_plugin semantic_release
 ```
 
@@ -18,11 +18,20 @@ Automated version managment and generator of release notes. Inspired by [semanti
 
 ## Available Actions
 
-### conventional_changelog
+### `conventional_changelog`
 
 - parses all commits since last version
-- group those commits by their type (fix, feat, docs, refactor, chore, etc)
+- groups those commits by their type (fix, feat, docs, refactor, chore, etc)
 - and creates formated release notes either in markdown or in slack format
+
+Available parameters:
+
+- `format: 'slack|markdown'` - defaults to `markdown` and formats the changelog for the destination you need
+- `title: 'My Title'` - is appended to the release notes title, "1.1.8 My Title (YYYY-MM-DD)"
+- `commit_url: 'https://github.com/username/repository/commit'` - prepended to the commit ID to build usable links
+- View other options by searching for `available_options` in `conventional_changelog.rb`
+
+Example:
 
 ```
 notes = conventional_changelog(format: 'slack', title: 'Android Alpha')
@@ -30,7 +39,7 @@ notes = conventional_changelog(format: 'slack', title: 'Android Alpha')
 
 <img src="https://raw.githubusercontent.com/xotahal/fastlane-plugin-semantic_release/master/docs/Changelog.png" />
 
-### analyze_commits
+### `analyze_commits`
 
 - analyzes your git history
 - finds last tag on current branch (for example ios/beta/1.3.2)
@@ -38,11 +47,13 @@ notes = conventional_changelog(format: 'slack', title: 'Android Alpha')
 - gets all commits since this tag
 - analyzes subject of every single commit and increases version number if there is a need (check conventional commit rules)
 - if next version number is higher then last version number it will recommend you to release this version
+
 ```
 isReleasable = analyze_commits(match: 'ios/beta*')
 ```
 
-It provides these variables in lane_context.
+It provides these variables in `lane_context`.
+
 ```
 ['RELEASE_ANALYZED', 'True if commits were analyzed.'],
 ['RELEASE_IS_NEXT_VERSION_HIGHER', 'True if next version is higher then last version'],
@@ -53,8 +64,8 @@ It provides these variables in lane_context.
 ['RELEASE_NEXT_PATCH_VERSION', 'Patch number of the next version'],
 ['RELEASE_NEXT_VERSION', 'Next version string in format (major.minor.patch)'],
 ```
-`next_version = lane_context[SharedValues::RELEASE_NEXT_VERSION]`
 
+`next_version = lane_context[SharedValues::RELEASE_NEXT_VERSION]`
 
 <img src="https://raw.githubusercontent.com/xotahal/fastlane-plugin-semantic_release/master/docs/Analyze.png" />
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Automated version managment and generator of release notes. Inspired by [semanti
 
 Available parameters:
 
-- `format: 'slack|markdown'` - defaults to `markdown` and formats the changelog for the destination you need
+- `format: 'slack|markdown|plain'` (defaults to `markdown`). This formats the changelog for the destination you need. If you're using this for TestFlight changelogs, we suggest using the `plain` option
 - `title: 'My Title'` - is appended to the release notes title, "1.1.8 My Title (YYYY-MM-DD)"
 - `display_title: true|false` (defaults to true) - allows you to hide the entire first line of the changelog
 - `display_links: true|false` (defaults to true) - allows you to hide links to commits from your changelog

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -132,31 +132,33 @@ module Fastlane
         # formats the text according to the style we're looking to use
 
         # Skips all styling
-        if format == "plain"
-          text
-        else
-          case style
-          when "title"
-            if format == "markdown"
-              "# #{text}"
-            else
-              "*#{text}*"
-            end
-          when "heading"
-            if format == "markdown"
-              "### #{text}"
-            else
-              "*#{text}*"
-            end
-          when "bold"
-            if format == "markdown"
-              "**#{text}**"
-            else
-              "*#{text}*"
-            end
+        case style
+        when "title"
+          if format == "markdown"
+            "# #{text}"
+          elsif format == "slack"
+            "*#{text}*"
           else
-            text # catchall, shouldn't be needed
+            text
           end
+        when "heading"
+          if format == "markdown"
+            "### #{text}"
+          elsif format == "slack"
+            "*#{text}*"
+          else
+            "#{text}:"
+          end
+        when "bold"
+          if format == "markdown"
+            "**#{text}**"
+          elsif format == "slack"
+            "*#{text}*"
+          else
+            text
+          end
+        else
+          text # catchall, shouldn't be needed
         end
       end
 

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -130,37 +130,46 @@ module Fastlane
 
       def self.style_text(text, format, style)
         # formats the text according to the style we're looking to use
-        case style
-        when "title"
-          if format == "markdown"
-            "# #{text}"
-          else
-            "*#{text}*"
-          end
-        when "heading"
-          if format == "markdown"
-            "### #{text}"
-          else
-            "*#{text}*"
-          end
-        when "bold"
-          if format == "markdown"
-            "**#{text}**"
-          else
-            "*#{text}*"
-          end
-        else
+
+        # Skips all styling
+        if format == "plain"
           text
+        else
+          case style
+          when "title"
+            if format == "markdown"
+              "# #{text}"
+            else
+              "*#{text}*"
+            end
+          when "heading"
+            if format == "markdown"
+              "### #{text}"
+            else
+              "*#{text}*"
+            end
+          when "bold"
+            if format == "markdown"
+              "**#{text}**"
+            else
+              "*#{text}*"
+            end
+          else
+            text # catchall, shouldn't be needed
+          end
         end
       end
 
       def self.style_link(text, url, format)
         # formats the link according to the output format we need
         # Slack link format is very specific, so we prefer the markdown version to be the more readable fallback
-        if format == "slack"
+        case format
+        when "slack"
           "<#{url}|#{text}>"
-        else
+        when "markdown"
           "[#{text}](#{url})"
+        else
+          url
         end
       end
 
@@ -205,7 +214,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(
             key: :format,
-            description: "You can use either markdown or slack",
+            description: "You can use either markdown, slack or plain",
             default_value: "markdown",
             optional: true
           ),

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -78,7 +78,7 @@ module Fastlane
             end
 
             if params[:display_author]
-              result += "- #{commit[:author_name]}"
+              result += " - #{commit[:author_name]}"
             end
 
             result += "\n"
@@ -100,7 +100,7 @@ module Fastlane
             end
 
             if params[:display_author]
-              result += "- #{commit[:author_name]}"
+              result += " - #{commit[:author_name]}"
             end
 
             result += "\n"

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -54,7 +54,7 @@ module Fastlane
           # write section only if there is at least one commit
           next if commits.none? { |commit| commit[:type] == type }
 
-          result += "\n\n"
+          result += "\n"
           result += style_text(sections[type.to_sym], format, "heading").to_s
           result += "\n"
 
@@ -85,7 +85,7 @@ module Fastlane
         end
 
         if commits.any? { |commit| commit[:is_breaking_change] == true }
-          result += "\n\n"
+          result += "\n"
           result += style_text("BREAKING CHANGES", format, "heading").to_s
           result += "\n"
 

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -221,7 +221,7 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :title,
-            description: "Title of release notes",
+            description: "Title for release notes",
             optional: true
           ),
           FastlaneCore::ConfigItem.new(
@@ -231,7 +231,7 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :order,
-            description: "You can change order of groups in release notes",
+            description: "You can change the order of groups in release notes",
             default_value: ["feat", "fix", "refactor", "perf", "chore", "test", "docs", "no_type"],
             type: Array,
             optional: true
@@ -243,18 +243,18 @@ module Fastlane
               feat: "Features",
               fix: "Bug fixes",
               refactor: "Code refactoring",
-              perf: "Performance improving",
+              perf: "Performance improvements",
               chore: "Building system",
               test: "Testing",
               docs: "Documentation",
-              no_type: "Rest work"
+              no_type: "Other work"
             },
             type: Hash,
             optional: true
           ),
           FastlaneCore::ConfigItem.new(
             key: :display_author,
-            description: "Wheter or not you want to display author of commit",
+            description: "Whether you want to show the author of the commit",
             default_value: false,
             type: Boolean,
             optional: true

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -75,8 +75,12 @@ module Fastlane
               result += " #{formatted_text}"
             end
 
-            styled_link = style_link(short_hash, url, format).to_s
-            result += " #{commit[:subject]} (#{styled_link})"
+            result += " #{commit[:subject]}"
+
+            if params[:display_links] == true
+              styled_link = style_link(short_hash, url, format).to_s
+              result += " (#{styled_link})"
+            end
 
             if params[:display_author]
               result += "- #{author_name}"
@@ -94,13 +98,19 @@ module Fastlane
           commits.each do |commit|
             next unless commit[:is_breaking_change]
 
+            # TODO: This largely duplicates the section above, and could be refactored
             author_name = commit[:author_name]
             short_hash = commit[:short_hash]
             hash = commit[:hash]
             url = "#{commit_url}/#{hash}"
-            styled_link = style_link(short_hash, url, format).to_s
 
-            result += "- #{commit[:breaking_change]} (#{styled_link})"
+            result += "- #{commit[:breaking_change]}" # This is the only unique part of this loop
+
+            # TODO: This largely duplicates the section above, and could be refactored
+            if params[:display_links] == true
+              styled_link = style_link(short_hash, url, format).to_s
+              result += " (#{styled_link})"
+            end
 
             if params[:display_author]
               result += "- #{author_name}"
@@ -242,6 +252,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :display_title,
             description: "Whether you want to hide the title/header with the version details at the top of the changelog",
+            default_value: true,
+            type: Boolean,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :display_links,
+            description: "Whether you want to display the links to commit IDs",
             default_value: true,
             type: Boolean,
             optional: true

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -63,11 +63,6 @@ module Fastlane
           commits.each do |commit|
             next if commit[:type] != type || commit[:is_merge]
 
-            author_name = commit[:author_name]
-            short_hash = commit[:short_hash]
-            hash = commit[:hash]
-            url = "#{commit_url}/#{hash}"
-
             result += "-"
 
             unless commit[:scope].nil?
@@ -78,12 +73,12 @@ module Fastlane
             result += " #{commit[:subject]}"
 
             if params[:display_links] == true
-              styled_link = style_link(short_hash, url, format).to_s
+              styled_link = build_commit_link(commit, commit_url, format).to_s
               result += " (#{styled_link})"
             end
 
             if params[:display_author]
-              result += "- #{author_name}"
+              result += "- #{commit[:author_name]}"
             end
 
             result += "\n"
@@ -97,23 +92,15 @@ module Fastlane
 
           commits.each do |commit|
             next unless commit[:is_breaking_change]
-
-            # TODO: This largely duplicates the section above, and could be refactored
-            author_name = commit[:author_name]
-            short_hash = commit[:short_hash]
-            hash = commit[:hash]
-            url = "#{commit_url}/#{hash}"
-
             result += "- #{commit[:breaking_change]}" # This is the only unique part of this loop
 
-            # TODO: This largely duplicates the section above, and could be refactored
             if params[:display_links] == true
-              styled_link = style_link(short_hash, url, format).to_s
+              styled_link = build_commit_link(commit, commit_url, format).to_s
               result += " (#{styled_link})"
             end
 
             if params[:display_author]
-              result += "- #{author_name}"
+              result += "- #{commit[:author_name]}"
             end
 
             result += "\n"
@@ -162,14 +149,17 @@ module Fastlane
         end
       end
 
-      def self.style_link(text, url, format)
+      def self.build_commit_link(commit, commit_url, format)
         # formats the link according to the output format we need
-        # Slack link format is very specific, so we prefer the markdown version to be the more readable fallback
+        short_hash = commit[:short_hash]
+        hash = commit[:hash]
+        url = "#{commit_url}/#{hash}"
+
         case format
         when "slack"
-          "<#{url}|#{text}>"
+          "<#{url}|#{short_hash}>"
         when "markdown"
-          "[#{text}](#{url})"
+          "[#{short_hash}](#{url})"
         else
           url
         end

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -41,20 +41,22 @@ module Fastlane
       def self.note_builder(format, commits, version, commit_url, params)
         sections = params[:sections]
 
-        title = version
-        title += " #{params[:title]}" if params[:title]
-        title += " (#{Date.today})"
+        result = ""
 
         # Begining of release notes
-        result = style_text(title, format, "title").to_s
+        if params[:display_title] == true
+          title = version
+          title += " #{params[:title]}" if params[:title]
+          title += " (#{Date.today})"
 
-        result += "\n"
+          result = style_text(title, format, "title").to_s
+          result += "\n\n"
+        end
 
         params[:order].each do |type|
           # write section only if there is at least one commit
           next if commits.none? { |commit| commit[:type] == type }
 
-          result += "\n"
           result += style_text(sections[type.to_sym], format, "heading").to_s
           result += "\n"
 
@@ -82,10 +84,10 @@ module Fastlane
 
             result += "\n"
           end
+          result += "\n"
         end
 
         if commits.any? { |commit| commit[:is_breaking_change] == true }
-          result += "\n"
           result += style_text("BREAKING CHANGES", format, "heading").to_s
           result += "\n"
 
@@ -97,7 +99,7 @@ module Fastlane
             hash = commit[:hash]
             url = "#{commit_url}/#{hash}"
             styled_link = style_link(short_hash, url, format).to_s
-            
+
             result += "- #{commit[:breaking_change]} (#{styled_link})"
 
             if params[:display_author]
@@ -106,7 +108,12 @@ module Fastlane
 
             result += "\n"
           end
+
+          result += "\n"
         end
+
+        # Trim any trailing newlines
+        result = result.rstrip!
 
         result
       end
@@ -229,6 +236,13 @@ module Fastlane
             key: :display_author,
             description: "Whether you want to show the author of the commit",
             default_value: false,
+            type: Boolean,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :display_title,
+            description: "Whether you want to hide the title/header with the version details at the top of the changelog",
+            default_value: true,
             type: Boolean,
             optional: true
           )

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -61,7 +61,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n\n### Rest work\n- Custom Merge... ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n\n### Other work\n- Custom Merge... ([short_hash](/long_hash))\n"
 
       expect(execute_lane_test).to eq(result)
     end
@@ -112,7 +112,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 * (2019-05-25)\n\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n\n*Rest work*\n- Custom Merge... (</long_hash|short_hash>)\n"
+      result = "*1.0.2 * (2019-05-25)\n\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n\n*Other work*\n- Custom Merge... (</long_hash|short_hash>)\n"
 
       expect(execute_lane_test_slack).to eq(result)
     end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -15,6 +15,14 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'slack' ) end").runner.execute(:test)
     end
 
+    def execute_lane_test_no_header
+      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( display_title: false ) end").runner.execute(:test)
+    end
+
+    def execute_lane_test_no_header_slack
+      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'slack', display_title: false ) end").runner.execute(:test)
+    end
+
     it "should create sections in markdown format" do
       commits = [
         "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
@@ -23,9 +31,21 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### Documentation\n- sub ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### Documentation\n- sub ([short_hash](/long_hash))"
 
       expect(execute_lane_test).to eq(result)
+    end
+
+    it "should skip the header if display_title is false" do
+      commits = [
+        "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
+      ]
+      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+      result = "### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))"
+
+      expect(execute_lane_test_no_header).to eq(result)
     end
 
     it "should display breaking change in markdown format" do
@@ -35,7 +55,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))"
 
       expect(execute_lane_test).to eq(result)
     end
@@ -47,7 +67,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))"
 
       expect(execute_lane_test).to eq(result)
     end
@@ -61,7 +81,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n### Other work\n- Custom Merge... ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n### Other work\n- Custom Merge... ([short_hash](/long_hash))"
 
       expect(execute_lane_test).to eq(result)
     end
@@ -74,9 +94,21 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*Documentation*\n- sub (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*Documentation*\n- sub (</long_hash|short_hash>)"
 
       expect(execute_lane_test_slack).to eq(result)
+    end
+
+    it "should skip the header if display_title is false in Slack format" do
+      commits = [
+        "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
+      ]
+      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+      result = "*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)"
+
+      expect(execute_lane_test_no_header_slack).to eq(result)
     end
 
     it "should display breaking change in Slack format" do
@@ -86,7 +118,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)"
 
       expect(execute_lane_test_slack).to eq(result)
     end
@@ -98,7 +130,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- *test:* sub (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- *test:* sub (</long_hash|short_hash>)"
 
       expect(execute_lane_test_slack).to eq(result)
     end
@@ -112,7 +144,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*Other work*\n- Custom Merge... (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*Other work*\n- Custom Merge... (</long_hash|short_hash>)"
 
       expect(execute_lane_test_slack).to eq(result)
     end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -23,6 +23,14 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'slack', display_title: false ) end").runner.execute(:test)
     end
 
+    def execute_lane_test_no_links
+      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( display_links: false ) end").runner.execute(:test)
+    end
+
+    def execute_lane_test_no_links_slack
+      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'slack', display_links: false ) end").runner.execute(:test)
+    end
+
     it "should create sections in markdown format" do
       commits = [
         "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
@@ -147,6 +155,32 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*Other work*\n- Custom Merge... (</long_hash|short_hash>)"
 
       expect(execute_lane_test_slack).to eq(result)
+    end
+
+    it "should skip links if display_title is false in markdown format" do
+      commits = [
+        "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
+        "fix: sub||long_hash|short_hash|Jiri Otahal|time"
+      ]
+      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub\n\n### Documentation\n- sub"
+
+      expect(execute_lane_test_no_links).to eq(result)
+    end
+
+    it "should skip links if display_title is false in Slack format" do
+      commits = [
+        "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
+        "fix: sub||long_hash|short_hash|Jiri Otahal|time"
+      ]
+      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub\n\n*Documentation*\n- sub"
+
+      expect(execute_lane_test_no_links_slack).to eq(result)
     end
 
     after do

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -101,7 +101,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "### Bug fixes\n- sub ([short_hash](/long_hash)) - Jiri Otahal\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash)) - Jiri Otahal"
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash)) - Jiri Otahal\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash)) - Jiri Otahal"
 
       expect(execute_lane_test_author).to eq(result)
     end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -23,7 +23,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n\n### Documentation\n- sub ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### Documentation\n- sub ([short_hash](/long_hash))\n"
 
       expect(execute_lane_test).to eq(result)
     end
@@ -35,7 +35,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))\n"
 
       expect(execute_lane_test).to eq(result)
     end
@@ -47,7 +47,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n"
 
       expect(execute_lane_test).to eq(result)
     end
@@ -61,7 +61,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n\n### Other work\n- Custom Merge... ([short_hash](/long_hash))\n"
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n### Other work\n- Custom Merge... ([short_hash](/long_hash))\n"
 
       expect(execute_lane_test).to eq(result)
     end
@@ -74,7 +74,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 (2019-05-25)*\n\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n\n*Documentation*\n- sub (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*Documentation*\n- sub (</long_hash|short_hash>)\n"
 
       expect(execute_lane_test_slack).to eq(result)
     end
@@ -86,7 +86,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 (2019-05-25)*\n\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)\n"
 
       expect(execute_lane_test_slack).to eq(result)
     end
@@ -98,7 +98,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 (2019-05-25)*\n\n\n*Bug fixes*\n- *test:* sub (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- *test:* sub (</long_hash|short_hash>)\n"
 
       expect(execute_lane_test_slack).to eq(result)
     end
@@ -112,7 +112,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 (2019-05-25)*\n\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n\n*Other work*\n- Custom Merge... (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*Other work*\n- Custom Merge... (</long_hash|short_hash>)\n"
 
       expect(execute_lane_test_slack).to eq(result)
     end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -15,7 +15,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'slack' ) end").runner.execute(:test)
     end
 
-    it "should create sections" do
+    it "should create sections in markdown format" do
       commits = [
         "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
         "fix: sub||long_hash|short_hash|Jiri Otahal|time"
@@ -28,7 +28,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       expect(execute_lane_test).to eq(result)
     end
 
-    it "should dispaly breaking change" do
+    it "should display breaking change in markdown format" do
       commits = [
         "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
       ]
@@ -40,7 +40,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       expect(execute_lane_test).to eq(result)
     end
 
-    it "should display scopes" do
+    it "should display scopes in markdown format" do
       commits = [
         "fix(test): sub||long_hash|short_hash|Jiri Otahal|time"
       ]
@@ -52,7 +52,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       expect(execute_lane_test).to eq(result)
     end
 
-    it "should skip merge" do
+    it "should skip merge in markdown format" do
       commits = [
         "Merge ...||long_hash|short_hash|Jiri Otahal|time",
         "Custom Merge...||long_hash|short_hash|Jiri Otahal|time",
@@ -66,7 +66,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       expect(execute_lane_test).to eq(result)
     end
 
-    it "should create sections" do
+    it "should create sections in Slack format" do
       commits = [
         "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
         "fix: sub||long_hash|short_hash|Jiri Otahal|time"
@@ -74,36 +74,36 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 * (2019-05-25)\n\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n\n*Documentation*\n- sub (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n\n*Documentation*\n- sub (</long_hash|short_hash>)\n"
 
       expect(execute_lane_test_slack).to eq(result)
     end
 
-    it "should dispaly breaking change" do
+    it "should display breaking change in Slack format" do
       commits = [
         "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
       ]
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 * (2019-05-25)\n\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)\n"
 
       expect(execute_lane_test_slack).to eq(result)
     end
 
-    it "should display scopes" do
+    it "should display scopes in Slack format" do
       commits = [
         "fix(test): sub||long_hash|short_hash|Jiri Otahal|time"
       ]
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 * (2019-05-25)\n\n\n*Bug fixes*\n- *test:* sub (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n\n*Bug fixes*\n- *test:* sub (</long_hash|short_hash>)\n"
 
       expect(execute_lane_test_slack).to eq(result)
     end
 
-    it "should skip merge" do
+    it "should skip merge in Slack format" do
       commits = [
         "Merge ...||long_hash|short_hash|Jiri Otahal|time",
         "Custom Merge...||long_hash|short_hash|Jiri Otahal|time",
@@ -112,7 +112,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "*1.0.2 * (2019-05-25)\n\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n\n*Other work*\n- Custom Merge... (</long_hash|short_hash>)\n"
+      result = "*1.0.2 (2019-05-25)*\n\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n\n*Other work*\n- Custom Merge... (</long_hash|short_hash>)\n"
 
       expect(execute_lane_test_slack).to eq(result)
     end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -19,6 +19,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'slack' ) end").runner.execute(:test)
     end
 
+    def execute_lane_test_author
+      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( display_author: true ) end").runner.execute(:test)
+    end
+
     def execute_lane_test_no_header
       Fastlane::FastFile.new.parse("lane :test do conventional_changelog( display_title: false ) end").runner.execute(:test)
     end
@@ -88,6 +92,18 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       result = "### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))"
 
       expect(execute_lane_test_no_header).to eq(result)
+    end
+
+    it "should show the author if display_author is true in markdown format" do
+      commits = [
+        "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
+      ]
+      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+      result = "### Bug fixes\n- sub ([short_hash](/long_hash)) - Jiri Otahal\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash)) - Jiri Otahal"
+
+      expect(execute_lane_test_author).to eq(result)
     end
 
     it "should skip the header if display_title is false in plain format" do

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -43,193 +43,187 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'slack', display_links: false ) end").runner.execute(:test)
     end
 
-    it "should create sections in markdown format" do
+    describe 'section creation' do
       commits = [
         "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
         "fix: sub||long_hash|short_hash|Jiri Otahal|time"
       ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### Documentation\n- sub ([short_hash](/long_hash))"
+      it 'should generate sections in markdown format' do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      expect(execute_lane_test).to eq(result)
+        result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### Documentation\n- sub ([short_hash](/long_hash))"
+
+        expect(execute_lane_test).to eq(result)
+      end
+
+      it "should create sections in plain format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+        result = "1.0.2 (2019-05-25)\n\nBug fixes:\n- sub (/long_hash)\n\nDocumentation:\n- sub (/long_hash)"
+
+        expect(execute_lane_test_plain).to eq(result)
+      end
+
+      it "should create sections in Slack format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+        result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*Documentation*\n- sub (</long_hash|short_hash>)"
+
+        expect(execute_lane_test_slack).to eq(result)
+      end
     end
 
-    it "should create sections in plain format" do
-      commits = [
-        "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
-        "fix: sub||long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-
-      result = "1.0.2 (2019-05-25)\n\nBug fixes:\n- sub (/long_hash)\n\nDocumentation:\n- sub (/long_hash)"
-
-      expect(execute_lane_test_plain).to eq(result)
-    end
-
-    it "should create sections in Slack format" do
-      commits = [
-        "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
-        "fix: sub||long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-
-      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*Documentation*\n- sub (</long_hash|short_hash>)"
-
-      expect(execute_lane_test_slack).to eq(result)
-    end
-
-    it "should skip the header if display_title is false in markdown format" do
+    describe 'hiding headers if display_title is false' do
       commits = [
         "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
       ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))"
+      it "should hide in markdown format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      expect(execute_lane_test_no_header).to eq(result)
+        result = "### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))"
+
+        expect(execute_lane_test_no_header).to eq(result)
+      end
+
+      it "should hide in plain format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+        result = "Bug fixes:\n- sub (/long_hash)\n\nBREAKING CHANGES:\n- Test (/long_hash)"
+
+        expect(execute_lane_test_no_header_plain).to eq(result)
+      end
+
+      it "should hide in slack format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+        result = "*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)"
+
+        expect(execute_lane_test_no_header_slack).to eq(result)
+      end
     end
 
-    it "should show the author if display_author is true in markdown format" do
+    describe 'showing the author if display_author is true' do
       commits = [
         "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
       ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash)) - Jiri Otahal\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash)) - Jiri Otahal"
+      it "should display in markdown format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      expect(execute_lane_test_author).to eq(result)
+        result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash)) - Jiri Otahal\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash)) - Jiri Otahal"
+
+        expect(execute_lane_test_author).to eq(result)
+      end
     end
 
-    it "should skip the header if display_title is false in plain format" do
-      commits = [
-        "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+    describe 'displaying a breaking change' do
+      it "should display in markdown format" do
+        commits = [
+          "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
+        ]
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "Bug fixes:\n- sub (/long_hash)\n\nBREAKING CHANGES:\n- Test (/long_hash)"
+        result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))"
 
-      expect(execute_lane_test_no_header_plain).to eq(result)
+        expect(execute_lane_test).to eq(result)
+      end
+
+      it "should display in slack format" do
+        commits = [
+          "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
+        ]
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+        result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)"
+
+        expect(execute_lane_test_slack).to eq(result)
+      end
     end
 
-    it "should skip the header if display_title is false in Slack format" do
-      commits = [
-        "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-
-      result = "*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)"
-
-      expect(execute_lane_test_no_header_slack).to eq(result)
-    end
-
-    it "should display a breaking change in markdown format" do
-      commits = [
-        "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))"
-
-      expect(execute_lane_test).to eq(result)
-    end
-
-    it "should display a breaking change in Slack format" do
-      commits = [
-        "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-
-      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)"
-
-      expect(execute_lane_test_slack).to eq(result)
-    end
-
-    it "should display scopes in markdown format" do
+    describe 'displaying scopes' do
       commits = [
         "fix(test): sub||long_hash|short_hash|Jiri Otahal|time"
       ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))"
+      it "should display in markdown format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      expect(execute_lane_test).to eq(result)
+        result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))"
+
+        expect(execute_lane_test).to eq(result)
+      end
+
+      it "should display in slack format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+        result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- *test:* sub (</long_hash|short_hash>)"
+
+        expect(execute_lane_test_slack).to eq(result)
+      end
     end
 
-    it "should display scopes in Slack format" do
-      commits = [
-        "fix(test): sub||long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-
-      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- *test:* sub (</long_hash|short_hash>)"
-
-      expect(execute_lane_test_slack).to eq(result)
-    end
-
-    it "should skip merge commits in markdown format" do
+    describe 'skipping merge conflicts' do
       commits = [
         "Merge ...||long_hash|short_hash|Jiri Otahal|time",
         "Custom Merge...||long_hash|short_hash|Jiri Otahal|time",
         "fix(test): sub||long_hash|short_hash|Jiri Otahal|time"
       ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n### Other work\n- Custom Merge... ([short_hash](/long_hash))"
+      it "should skip in markdown format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      expect(execute_lane_test).to eq(result)
+        result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n### Other work\n- Custom Merge... ([short_hash](/long_hash))"
+
+        expect(execute_lane_test).to eq(result)
+      end
+
+      it "should skip in slack format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+        result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- *test:* sub (</long_hash|short_hash>)\n\n*Other work*\n- Custom Merge... (</long_hash|short_hash>)"
+
+        expect(execute_lane_test_slack).to eq(result)
+      end
     end
 
-    it "should skip merge commits in Slack format" do
-      commits = [
-        "Merge ...||long_hash|short_hash|Jiri Otahal|time",
-        "Custom Merge...||long_hash|short_hash|Jiri Otahal|time",
-        "fix: sub||long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-
-      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*Other work*\n- Custom Merge... (</long_hash|short_hash>)"
-
-      expect(execute_lane_test_slack).to eq(result)
-    end
-
-    it "should skip links if display_title is false in markdown format" do
+    describe 'hiding links if display_links is false' do
       commits = [
         "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
         "fix: sub||long_hash|short_hash|Jiri Otahal|time"
       ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub\n\n### Documentation\n- sub"
+      it "should hide in markdown format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      expect(execute_lane_test_no_links).to eq(result)
-    end
+        result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub\n\n### Documentation\n- sub"
 
-    it "should skip links if display_title is false in Slack format" do
-      commits = [
-        "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
-        "fix: sub||long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+        expect(execute_lane_test_no_links).to eq(result)
+      end
 
-      result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub\n\n*Documentation*\n- sub"
+      it "should hide in Slack format" do
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      expect(execute_lane_test_no_links_slack).to eq(result)
+        result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub\n\n*Documentation*\n- sub"
+
+        expect(execute_lane_test_no_links_slack).to eq(result)
+      end
     end
 
     after do

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -60,7 +60,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "1.0.2 (2019-05-25)\n\nBug fixes\n- sub (/long_hash)\n\nDocumentation\n- sub (/long_hash)"
+      result = "1.0.2 (2019-05-25)\n\nBug fixes:\n- sub (/long_hash)\n\nDocumentation:\n- sub (/long_hash)"
 
       expect(execute_lane_test_plain).to eq(result)
     end
@@ -97,7 +97,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
       allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
 
-      result = "Bug fixes\n- sub (/long_hash)\n\nBREAKING CHANGES\n- Test (/long_hash)"
+      result = "Bug fixes:\n- sub (/long_hash)\n\nBREAKING CHANGES:\n- Test (/long_hash)"
 
       expect(execute_lane_test_no_header_plain).to eq(result)
     end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -36,56 +36,6 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       expect(execute_lane_test).to eq(result)
     end
 
-    it "should skip the header if display_title is false" do
-      commits = [
-        "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-
-      result = "### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))"
-
-      expect(execute_lane_test_no_header).to eq(result)
-    end
-
-    it "should display breaking change in markdown format" do
-      commits = [
-        "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))"
-
-      expect(execute_lane_test).to eq(result)
-    end
-
-    it "should display scopes in markdown format" do
-      commits = [
-        "fix(test): sub||long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))"
-
-      expect(execute_lane_test).to eq(result)
-    end
-
-    it "should skip merge in markdown format" do
-      commits = [
-        "Merge ...||long_hash|short_hash|Jiri Otahal|time",
-        "Custom Merge...||long_hash|short_hash|Jiri Otahal|time",
-        "fix(test): sub||long_hash|short_hash|Jiri Otahal|time"
-      ]
-      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-
-      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n### Other work\n- Custom Merge... ([short_hash](/long_hash))"
-
-      expect(execute_lane_test).to eq(result)
-    end
-
     it "should create sections in Slack format" do
       commits = [
         "docs: sub|body|long_hash|short_hash|Jiri Otahal|time",
@@ -97,6 +47,18 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*Documentation*\n- sub (</long_hash|short_hash>)"
 
       expect(execute_lane_test_slack).to eq(result)
+    end
+
+    it "should skip the header if display_title is false" do
+      commits = [
+        "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
+      ]
+      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+      result = "### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))"
+
+      expect(execute_lane_test_no_header).to eq(result)
     end
 
     it "should skip the header if display_title is false in Slack format" do
@@ -111,7 +73,19 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       expect(execute_lane_test_no_header_slack).to eq(result)
     end
 
-    it "should display breaking change in Slack format" do
+    it "should display a breaking change in markdown format" do
+      commits = [
+        "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
+      ]
+      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- sub ([short_hash](/long_hash))\n\n### BREAKING CHANGES\n- Test ([short_hash](/long_hash))"
+
+      expect(execute_lane_test).to eq(result)
+    end
+
+    it "should display a breaking change in Slack format" do
       commits = [
         "fix: sub|BREAKING CHANGE: Test|long_hash|short_hash|Jiri Otahal|time"
       ]
@@ -121,6 +95,18 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub (</long_hash|short_hash>)\n\n*BREAKING CHANGES*\n- Test (</long_hash|short_hash>)"
 
       expect(execute_lane_test_slack).to eq(result)
+    end
+
+    it "should display scopes in markdown format" do
+      commits = [
+        "fix(test): sub||long_hash|short_hash|Jiri Otahal|time"
+      ]
+      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))"
+
+      expect(execute_lane_test).to eq(result)
     end
 
     it "should display scopes in Slack format" do
@@ -135,7 +121,21 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       expect(execute_lane_test_slack).to eq(result)
     end
 
-    it "should skip merge in Slack format" do
+    it "should skip merge commits in markdown format" do
+      commits = [
+        "Merge ...||long_hash|short_hash|Jiri Otahal|time",
+        "Custom Merge...||long_hash|short_hash|Jiri Otahal|time",
+        "fix(test): sub||long_hash|short_hash|Jiri Otahal|time"
+      ]
+      allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+      allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+
+      result = "# 1.0.2 (2019-05-25)\n\n### Bug fixes\n- **test:** sub ([short_hash](/long_hash))\n\n### Other work\n- Custom Merge... ([short_hash](/long_hash))"
+
+      expect(execute_lane_test).to eq(result)
+    end
+
+    it "should skip merge commits in Slack format" do
       commits = [
         "Merge ...||long_hash|short_hash|Jiri Otahal|time",
         "Custom Merge...||long_hash|short_hash|Jiri Otahal|time",


### PR DESCRIPTION
Apologies - this is a fairly large PR and includes several features - bad practice, I know 🙈 

I wanted to submit it anyway and ask for your feedback - if necessary, I can unpick changes later on (and perhaps break into separate PRs, though **if possible**, I'd prefer to avoid this as it will involve extra work. Let me know, anyway!

I've tested this quite a bit (and also introduced lots more tests) - I think everything works pretty well and makes the plugin a lot more adaptable and powerful. But that's a biased opinion 🤣. I'd love it if you would consider merging these.

Here's a summary of the main changes...

## Refactoring of changelog generation + new `format: 'plain'` formatting option. Here's how this looks:

I added a new `format: 'plain'` option. This was designed to generate the changelog in a format that works nicely with TestFlight (which doesn't support markdown). Here's how the output looks for this:

````
1.5.1 (2019-11-10)

Features:
- new display_title parameter to hide the header in changelog (https://github.com/abc123)

Bug fixes:
- clean up text strings (https://github.com/abc123)
````

There are now 3 different options that can be passed into the plugin for formatting:

- `plain`
- `markdown`
- `slack`

While it arguably make more sense for `plain` to be the default, I didn't want this to be a breaking change, so I've left `markdown` as the default.

There were 2 large `self.markdown` and `self.slack` chunks inside `conventional_changelog.rb`. As I think you know, these had a lot of duplicated code. I refactored both of them so that all 3 of the `format` options can use the same logic to generate the changelog. This all lives inside a `note_builder` method.

As part of this, I created a `style_text` method which should be extensible in the future, if we wanted to add extra formatting options (e.g. a `html` option).

### Addition of new `display_title` option for changelog

In some situations, it doesn't make sense to have the version number and title placed at the top of the changelog. That's the case in TestFlight, and also in GitHub. For example, here's how the GH releases page looks for this repo, with the duplicated titles:

![image](https://user-images.githubusercontent.com/1898889/68542384-f1d45b00-03a3-11ea-962f-3b1149badb74.png)

I've left the defaults unchanged, but I did introduce a new `display_title` option. Defaults to `true`.

If this is set to `false`, it will remove the title (and newlines) from the top of the changelog. So the output will look a little like this (in plain text mode):

````
Features:
- new display_title parameter to hide the header in changelog (https://github.com/abc123)

Bug fixes:
- clean up text strings (https://github.com/abc123)
````

### Addition of new `display_links` option for changelog

Sometimes it doesn't make sense to include the links to the git commits inside the prepared changelog (e.g. in a context which doesn't support them, like TestFlight changelogs).

I've left the defaults unchanged, but I did introduce a new `display_links` option. Defaults to `true`.

If this is set to `false`, it will remove the links from changelog entries. So the output will look a little like this (in plain text mode):

````
Features:
- new display_title parameter to hide the header in changelog

Bug fixes:
- clean up text strings
````

### Other refactoring

- While refactoring changelog generation, I tried to clean up the output as much as possible to remove redundant `\n` characters in between sections. I also added `result.rstrip!` to remove any trailing `\n` characters from the end of the changelog.
- I tweaked various typos throughout README and the source.
- I tried to expand the documentation a little - I didn't know of a few features myself until I started to try to modify the plugin, so hopefully this will help others! This includes added information about running tests into the documentation.