### PR TITLE
feat: allow exclusion of scopes from analyze_commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ notes = conventional_changelog(format: 'slack', title: 'Android Alpha')
 - analyzes subject of every single commit and increases version number if there is a need (check conventional commit rules)
 - if next version number is higher then last version number it will recommend you to release this version
 
+Options:
+
+- `ignore_scopes: ['android','windows']`: allows you to ignore any commits which include a given scope, like this one: `feat(android): add functionality not relevant to the release we are producing`
+
+Example usage:
+
 ```
 isReleasable = analyze_commits(match: 'ios/beta*')
 ```

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -84,6 +84,14 @@ module Fastlane
             releases: releases
           )
 
+          unless commit[:scope].nil?
+            # if this commit has a scope, then we need to inspect to see if that is one of the scopes we're trying to exclude
+            scope = commit[:scope]
+            scopes_to_ignore = params[:ignore_scopes]
+            # if it is, we'll skip this commit when bumping versions
+            next if scopes_to_ignore.include?(scope) #=> true
+          end
+
           if commit[:release] == "major" || commit[:is_breaking_change]
             next_major += 1
             next_minor = 0
@@ -154,6 +162,13 @@ module Fastlane
             key: :tag_version_match,
             description: "To parse version number from tag name",
             default_value: '\d+\.\d+\.\d+'
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :ignore_scopes,
+            description: "To ignore certain scopes when calculating releases",
+            default_value: [],
+            type: Array,
+            optional: true
           )
         ]
       end

--- a/spec/analyze_commits_spec.rb
+++ b/spec/analyze_commits_spec.rb
@@ -5,8 +5,15 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
     before do
     end
 
-    def execute_lane_test
-      Fastlane::FastFile.new.parse("lane :test do analyze_commits( match: 'v*') end").runner.execute(:test)
+    def test_analyze_commits(commits)
+      # for simplicity, these two actions are grouped together because they need to be run for every test,
+      # but require different commits to be passed each time. So we can't use the "before :each" for this
+      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag).and_return('v1.0.8-1-g71ce4d8')
+      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
+    end
+
+    def execute_lane_test(params)
+      Fastlane::FastFile.new.parse("lane :test do analyze_commits( #{params} ) end").runner.execute(:test)
     end
 
     it "should increment fix and return true" do
@@ -14,10 +21,9 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
         "docs: ...|",
         "fix: ...|"
       ]
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag).and_return('v1.0.8-1-g71ce4d8')
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
+      test_analyze_commits(commits)
 
-      expect(execute_lane_test).to eq(true)
+      expect(execute_lane_test(match: 'v*')).to eq(true)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.9")
     end
 
@@ -27,10 +33,9 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
         "feat: ...|",
         "fix: ...|"
       ]
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag).and_return('v1.0.8-1-g71ce4d8')
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
+      test_analyze_commits(commits)
 
-      expect(execute_lane_test).to eq(true)
+      expect(execute_lane_test(match: 'v*')).to eq(true)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.1.1")
     end
 
@@ -40,24 +45,61 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
         "feat: ...|",
         "fix: ...|BREAKING CHANGE: Test"
       ]
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag).and_return('v1.0.8-1-g71ce4d8')
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
+      test_analyze_commits(commits)
 
-      expect(execute_lane_test).to eq(true)
+      expect(execute_lane_test(match: 'v*')).to eq(true)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("2.0.0")
     end
 
-    it "should correctly parse scopes" do
+    describe "scopes" do
       commits = [
-        "docs(scope): ...|",
-        "feat(test): ...|",
-        "fix(test): ...|"
+        "fix(scope): ...|",
+        "feat(ios): ...|",
+        "fix(ios): ...|",
+        "feat(android): ...|",
+        "fix(android): ...|"
       ]
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag).and_return('v1.0.8-1-g71ce4d8')
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
 
-      expect(execute_lane_test).to eq(true)
-      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.1.1")
+      describe "parsing of scopes" do
+        it "should correctly parse and output scopes" do
+          test_analyze_commits(commits)
+
+          expect(execute_lane_test(match: 'v*')).to eq(true)
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.2.1")
+        end
+      end
+
+      describe "filtering by scopes" do
+        it "should accommodate an empty ignore_scopes array" do
+          test_analyze_commits(commits)
+
+          expect(execute_lane_test(match: 'v*', ignore_scopes: [])).to eq(true)
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.2.1")
+        end
+
+        it "should skip a single scopes if it has been added to ignore_scopes" do
+          test_analyze_commits(commits)
+
+          expect(execute_lane_test(match: 'v*', ignore_scopes: ['android'])).to eq(true)
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.1.1")
+        end
+
+        it "should skip multiple scopes if they have been added to ignore_scopes" do
+          test_analyze_commits(commits)
+
+          expect(execute_lane_test(match: 'v*', ignore_scopes: ['android', 'ios'])).to eq(true)
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.9")
+        end
+
+        it "should not pass analysis checks if all commits are caught by excluded scopes" do
+          commits = [
+            "fix(ios): ...|"
+          ]
+          test_analyze_commits(commits)
+
+          expect(execute_lane_test(match: 'v*', ignore_scopes: ['ios'])).to eq(false)
+        end
+      end
     end
 
     it "should return false since there is no change that would increase version" do
@@ -66,10 +108,9 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
         "chore: ...|",
         "refactor: ...|"
       ]
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag).and_return('v1.0.8-1-g71ce4d8')
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
+      test_analyze_commits(commits)
 
-      expect(execute_lane_test).to eq(false)
+      expect(execute_lane_test(match: 'v*')).to eq(false)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.8")
     end
 
@@ -78,10 +119,9 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
         "Merge ...|",
         "Custom ...|"
       ]
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag).and_return('v1.0.8-1-g71ce4d8')
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
+      test_analyze_commits(commits)
 
-      expect(execute_lane_test).to eq(false)
+      expect(execute_lane_test(match: 'v*')).to eq(false)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.8")
     end
 
@@ -96,10 +136,9 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
         "chore: add alpha deploy triggered by alpha branch|",
         "fix: fix navigation after user logs in|"
       ]
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag).and_return('v1.0.8-1-g71ce4d8')
-      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
+      test_analyze_commits(commits)
 
-      expect(execute_lane_test).to eq(true)
+      expect(execute_lane_test(match: 'v*')).to eq(true)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.10")
     end
 


### PR DESCRIPTION
Discussed over in https://github.com/xotahal/fastlane-plugin-semantic_release/issues/7

I thought I'd put out the PR here, because otherwise it'll just get abandoned - it should work as expected - when you call `analyze_commits(ignore_scopes: ['android','windows'])`, it will ignore any commits which have those scopes within them.

What I'm not happy about, is that even if the commits are ignored by the `analyze_commits` action, they would still be included in the `conventional_changelog`.

Ideally, excluding a commit like this would create something like a `Fastlane::Actions::SharedValues::RELEASE_COMMITS` array, which would not include the ignored scopes, and the `conventional_changelog` action would automatically read from that array.

But that's more of a change to the way this plugin works, so would have to be handled separately 😄 

I'm not going to have any time to touch this for the next few months, sadly. So if anybody wants to build upon it, etc, they're more than welcome to.