### PR TITLE
Add single step mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ fastlane/README.md
 fastlane/report.xml
 coverage
 test-results
+.bundle/
+vendor/bundle/

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -122,7 +122,7 @@ module Fastlane
               bumped_patch = single_step
             end
           elsif commit[:release] == "minor"
-            unless bumped_major
+            unless bumped_minor
               next_minor += 1
               next_patch = 0
               bumped_minor = single_step

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -180,7 +180,7 @@ module Fastlane
 
         if hash_lines.to_i > 1
           UI.error("#{git_command} resulted to more than 1 hash")
-          UI.error('This usualy happens when you pull only part of a git history. Check out how you pull the repo! "git fetch" should be enough.')
+          UI.error('This usually happens when you pull only part of a git history. Check out how you pull the repo! "git fetch" should be enough.')
           Actions.sh(git_command, log: true).chomp
           return false
         end

--- a/spec/analyze_commits_spec.rb
+++ b/spec/analyze_commits_spec.rb
@@ -211,7 +211,7 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
           allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
 
           expect(execute_lane_test(match: 'v*', single_step: true)).to eq(true)
-          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("0.2.0")
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("0.1.0")
           expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_LAST_INCOMPATIBLE_CODEPUSH_VERSION]).to eq("0.0.0")
         end
       end


### PR DESCRIPTION
This is an optional mode where the version number will only be incremented by the minimum possible amount, regardless of how many underlying commits there were.
For example, assume the last release was `v1.2.3` and your commit log is as follows:
```
fix: ...
feat: ...
fix: ...
fix: ...
```
If `single_step` is `false` (the default), this will result in the generated next version `v1.3.2`.
Setting `single_step` to `true`, however, will result in the version `v1.3.0`.

This is useful if you want to bundle multiple changes into a single release without it looking like versions have been skipped. For example, doing a major refactor could result in multiple breaking changes being committed separately, which could then result in the major version being bumped from, for example, 2 directly to 5, which could confuse consumers as to where versions 3 and 4 went.

---

#### Notes:
  - Since this change defaults to false, it is backwards-compatible.
  - The code in `AnalyzeCommitsAction::is_releasable` is not the cleanest, as making it more readable ironically caused the code complexity metric to complain.
  - Setting `single_step` to `true` locks `RELEASE_LAST_INCOMPATIBLE_CODEPUSH_VERSION` to `0.0.0`, as it is no longer feasible to calculate due to there no longer being intervening versions. If there is a decent workaround for this that I just didn't think of, I'd happily implement it.