### PR TITLE
Add commit_format option

### DIFF
--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -175,12 +175,14 @@ module Fastlane
       def self.parse_commits(commits)
         parsed = []
         # %s|%b|%H|%h|%an|%at
+        format_pattern = lane_context[SharedValues::CONVENTIONAL_CHANGELOG_ACTION_FORMAT_PATTERN]
         commits.each do |line|
           splitted = line.split("|")
 
           commit = Helper::SemanticReleaseHelper.parse_commit(
             commit_subject: splitted[0],
-            commit_body: splitted[1]
+            commit_body: splitted[1],
+            pattern: format_pattern
           )
 
           commit[:hash] = splitted[2]

--- a/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
+++ b/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
@@ -18,7 +18,7 @@ module Fastlane
         commit_body = params[:commit_body]
         releases = params[:releases]
         codepush_friendly = params[:codepush_friendly]
-        pattern = /^(docs|fix|feat|chore|style|refactor|perf|test)(\((.*)\))?(!?)\: (.*)/
+        pattern = /^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)/
         breaking_change_pattern = /BREAKING CHANGES?: (.*)/
         codepush_pattern = /codepush?: (.*)/
 
@@ -32,13 +32,13 @@ module Fastlane
 
         unless matched.nil?
           type = matched[1]
-          scope = matched[3]
+          scope = matched[2]
 
           result[:is_valid] = true
           result[:type] = type
           result[:scope] = scope
-          result[:has_exclamation_mark] = matched[4] == '!'
-          result[:subject] = matched[5]
+          result[:has_exclamation_mark] = matched[3] == '!'
+          result[:subject] = matched[4]
 
           unless releases.nil?
             result[:release] = releases[type.to_sym]

--- a/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
+++ b/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
@@ -5,6 +5,13 @@ module Fastlane
 
   module Helper
     class SemanticReleaseHelper
+      def self.format_patterns
+        return {
+          "default" => /^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)/,
+          "angular" => /^(\w*)(?:\((.*)\))?(): (.*)/
+        }
+      end
+
       # class methods that you define here become available in your action
       # as `Helper::SemanticReleaseHelper.your_method`
       #
@@ -18,7 +25,7 @@ module Fastlane
         commit_body = params[:commit_body]
         releases = params[:releases]
         codepush_friendly = params[:codepush_friendly]
-        pattern = /^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)/
+        pattern = params[:pattern]
         breaking_change_pattern = /BREAKING CHANGES?: (.*)/
         codepush_pattern = /codepush?: (.*)/
 

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Fastlane::Actions::ConventionalChangelogAction do
   describe "Conventional Changelog" do
     before do
+      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::CONVENTIONAL_CHANGELOG_ACTION_FORMAT_PATTERN] = Fastlane::Helper::SemanticReleaseHelper.format_patterns["default"]
       Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION] = '1.0.2'
       Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_ANALYZED] = true
     end
@@ -223,6 +224,37 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         result = "*1.0.2 (2019-05-25)*\n\n*Bug fixes*\n- sub\n\n*Documentation*\n- sub"
 
         expect(execute_lane_test_no_links_slack).to eq(result)
+      end
+    end
+
+    describe "commit format" do
+      format_pattern = /^prefix-(foo|bar|baz)(?:\.(.*))?(): (.*)/
+      commits = [
+        "prefix-foo: sub|body|long_hash|short_hash|Jiri Otahal|time",
+        "prefix-bar: sub|body|long_hash|short_hash|Jiri Otahal|time",
+        "prefix-baz.android: sub|body|long_hash|short_hash|Jiri Otahal|time",
+        "prefix-qux: sub|body|long_hash|short_hash|Jiri Otahal|time"
+      ]
+
+      before do
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::CONVENTIONAL_CHANGELOG_ACTION_FORMAT_PATTERN] = format_pattern
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+      end
+
+      it "should use the commit format" do
+        result = "# 1.0.2 (2019-05-25)\n\n### Bazz\n- **android:** sub ([short_hash](/long_hash))\n\n### Foo\n- sub ([short_hash](/long_hash))\n\n### Bar\n- sub ([short_hash](/long_hash))\n\n### Other\n- prefix-qux: sub ([short_hash](/long_hash))"
+
+        changelog = execute_lane_test(
+          order: ['baz', 'foo', 'bar', 'no_type'],
+          sections: {
+            foo: "Foo",
+            bar: "Bar",
+            baz: "Bazz",
+            no_type: "Other"
+          }
+        )
+        expect(changelog).to eq(result)
       end
     end
 

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -7,40 +7,40 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_ANALYZED] = true
     end
 
-    def execute_lane_test
-      Fastlane::FastFile.new.parse("lane :test do conventional_changelog end").runner.execute(:test)
+    def execute_lane_test(params = {})
+      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( #{params} ) end").runner.execute(:test)
     end
 
     def execute_lane_test_plain
-      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'plain' ) end").runner.execute(:test)
+      execute_lane_test(format: 'plain')
     end
 
     def execute_lane_test_slack
-      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'slack' ) end").runner.execute(:test)
+      execute_lane_test(format: 'slack')
     end
 
     def execute_lane_test_author
-      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( display_author: true ) end").runner.execute(:test)
+      execute_lane_test(display_author: true)
     end
 
     def execute_lane_test_no_header
-      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( display_title: false ) end").runner.execute(:test)
+      execute_lane_test(display_title: false)
     end
 
     def execute_lane_test_no_header_plain
-      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'plain', display_title: false ) end").runner.execute(:test)
+      execute_lane_test(format: 'plain', display_title: false)
     end
 
     def execute_lane_test_no_header_slack
-      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'slack', display_title: false ) end").runner.execute(:test)
+      execute_lane_test(format: 'slack', display_title: false)
     end
 
     def execute_lane_test_no_links
-      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( display_links: false ) end").runner.execute(:test)
+      execute_lane_test(display_links: false)
     end
 
     def execute_lane_test_no_links_slack
-      Fastlane::FastFile.new.parse("lane :test do conventional_changelog( format: 'slack', display_links: false ) end").runner.execute(:test)
+      execute_lane_test(format: 'slack', display_links: false)
     end
 
     describe 'section creation' do


### PR DESCRIPTION
This adds the new option commit_format. It is either a string, in which case it resolves to one of the pre-defined patterns in SemanticReleaseHelper.format_patterns, or it can be passed a Regexp object, in which case that becomes the pattern through which the commit messages will be processed.

Examples:
```ruby
lane :changelog_angular do
  analyze_commits(match: 'v*', commit_format: 'angular')
  notes = conventional_changelog
  puts(notes)
end

lane :changelog_custom do
  # will match commits of the form 'cl-<type>[.scope]= <subject>'
  analyze_commits(match: 'v*', commit_format: /^cl-(\w*)(?:\.(.*))?()= (.*)/)
  notes = conventional_changelog
  puts(notes)
end
```

---

#### Notes:
  - Since this change defaults to the previous value, it is backwards-compatible.
  - This adds two built-in options:
    - `default` - the default previous behavior
    - `angular` - [the angular format](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/parser-opts.js#L4)

---

Closes #22