### PR TITLE
Clean up analyze_commits printout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ fastlane/README.md
 fastlane/report.xml
 coverage
 test-results
+.bundle/
+vendor/bundle/

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -90,11 +90,13 @@ module Fastlane
         releases = params[:releases]
 
         splitted.each do |line|
+          parts = line.split("|")
+          subject = parts[0].strip
           # conventional commits are in format
           # type: subject (fix: app crash - for example)
           commit = Helper::SemanticReleaseHelper.parse_commit(
-            commit_subject: line.split("|")[0],
-            commit_body: line.split("|")[1],
+            commit_subject: subject,
+            commit_body: parts[1],
             releases: releases
           )
 
@@ -118,7 +120,7 @@ module Fastlane
           end
 
           next_version = "#{next_major}.#{next_minor}.#{next_patch}"
-          UI.message("#{next_version}: #{line}") if params[:show_version_path]
+          UI.message("#{next_version}: #{subject}") if params[:show_version_path]
         end
 
         next_version = "#{next_major}.#{next_minor}.#{next_patch}"

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -118,7 +118,7 @@ module Fastlane
           end
 
           next_version = "#{next_major}.#{next_minor}.#{next_patch}"
-          UI.message("#{next_version}: #{line}")
+          UI.message("#{next_version}: #{line}") if params[:show_version_path]
         end
 
         next_version = "#{next_major}.#{next_minor}.#{next_patch}"
@@ -250,6 +250,13 @@ module Fastlane
             description: "To ignore certain scopes when calculating releases",
             default_value: [],
             type: Array,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :show_version_path,
+            description: "True if you want to print out the version calculated for each commit",
+            default_value: true,
+            type: Boolean,
             optional: true
           ),
           FastlaneCore::ConfigItem.new(


### PR DESCRIPTION
Running `analyze_commits` with more than one commit results in all but the first commit on the next line from the version number. Additionally, they all end in the `|` separator:
```
[11:20:19]: -----------------------------
[11:20:19]: --- Step: analyze_commits ---
[11:20:19]: -----------------------------
[11:20:19]: Found a tag v1.9.1 associated with version 1.9.1
[11:20:19]: Found 3 commits since last release
[11:20:19]: 1.9.1: chore(gitignore): ignore bundle-generated directories|
[11:20:19]: 1.10.0: 
feat: add option to hide version + commit printout|
[11:20:19]: 1.11.0: 
feat: clean up version path printout|
[11:20:19]: Next version (1.11.0) is higher than last version (1.9.1). This version should be released.
```

This change makes it so only the stripped subject is printed out:
```
[11:21:47]: -----------------------------
[11:21:47]: --- Step: analyze_commits ---
[11:21:47]: -----------------------------
[11:21:47]: Found a tag v1.9.1 associated with version 1.9.1
[11:21:47]: Found 3 commits since last release
[11:21:47]: 1.9.1: chore(gitignore): ignore bundle-generated directories
[11:21:47]: 1.10.0: feat: add option to hide version + commit printout
[11:21:47]: 1.11.0: feat: clean up version path printout
[11:21:47]: Next version (1.11.0) is higher than last version (1.9.1). This version should be released.
```

Additionally this adds a new option, `show_version_path`, which, if set to `false` (`true` by default) will disable the printout entirely:
```
[11:24:35]: -----------------------------
[11:24:35]: --- Step: analyze_commits ---
[11:24:35]: -----------------------------
[11:24:35]: Found a tag v1.9.1 associated with version 1.9.1
[11:24:36]: Found 3 commits since last release
[11:24:36]: Next version (1.11.0) is higher than last version (1.9.1). This version should be released.
```

---

#### Notes:
  - The new option `show_version_path`, since it defaults to `true`, is fully backwards-compatible.
  - Changing the printout format is a *potentially* breaking change, but only if people are scraping the command's `stdout`, which I don't think should count, as that is not supported behavior anyway.