### PR TITLE
Allow tags to contain hyphens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ fastlane/README.md
 fastlane/report.xml
 coverage
 test-results
+.bundle/
+vendor/bundle/

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -58,7 +58,7 @@ module Fastlane
         else
           # Tag's format is v2.3.4-5-g7685948
           # See git describe man page for more info
-          tag_name = tag.split('-')[0].strip
+          tag_name = tag.split('-')[0...-2].join('-').strip
           parsed_version = tag_name.match(params[:tag_version_match])
 
           if parsed_version.nil?

--- a/spec/analyze_commits_spec.rb
+++ b/spec/analyze_commits_spec.rb
@@ -154,6 +154,34 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.10")
     end
 
+    describe "tags" do
+      it "should properly strip off git describe suffix" do
+        commits = [
+          "docs: ...|",
+          "fix: ...|"
+        ]
+        allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag).and_return('v1.0.8-1-g71ce4d8')
+        allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
+
+        expect(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag_hash).with(tag_name: 'v1.0.8', debug: false)
+        expect(execute_lane_test(match: 'v*')).to eq(true)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.9")
+      end
+
+      it "should allow for user-defined hyphens" do
+        commits = [
+          "docs: ...|",
+          "fix: ...|"
+        ]
+        allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag).and_return('ios-v1.0.8-beta.1-1-g71ce4d8')
+        allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
+
+        expect(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag_hash).with(tag_name: 'ios-v1.0.8-beta.1', debug: false)
+        expect(execute_lane_test(match: 'v*')).to eq(true)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.9")
+      end
+    end
+
     it "should provide codepush last version" do
       commits = [
         "fix: ...|codepush: ok",


### PR DESCRIPTION
Currently, in order to drop the `-[new commits]-g[objectname]` suffix that `git describe` appends, [this statement](https://github.com/xotahal/fastlane-plugin-semantic_release/blob/master/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb#L61) just throws away everything after the first hyphen. This works great until you have a tag with an actual hyphen in it (for example, `v1.0.0-beta.1`).

This fix makes it only strip off the last two hyphenated sections of the `git describe` output, thus allowing for arbitrary hyphens in the tag itself.