### PR TITLE
Support Monorepo's

### DIFF
--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -338,7 +338,7 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :include_scopes,
-            description: "Only allow commits with certain scopes when calculating releases",
+            description: "To only include certain scopes when calculating releases",
             default_value: [],
             type: Array,
             optional: true

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -28,7 +28,7 @@ module Fastlane
       end
 
       def self.get_last_tag_hash(params)
-        command = "git rev-list -n 1 refs/tags/#{params[:tag_name]} -- #{Dir.pwd}"
+        command = "git rev-list -n 1 refs/tags/#{params[:tag_name]}"
         Actions.sh(command, log: params[:debug]).chomp
       end
 
@@ -43,7 +43,7 @@ module Fastlane
 
       def self.get_beginning_of_next_sprint(params)
         # command to get first commit
-        git_command = "git rev-list --max-parents=0 HEAD -- #{Dir.pwd}"
+        git_command = "git rev-list --max-parents=0 HEAD"
 
         tag = get_last_tag(match: params[:match], debug: params[:debug])
 
@@ -150,6 +150,15 @@ module Fastlane
             next if scopes_to_ignore.include?(scope) #=> true
           end
 
+          scopes_to_include = params[:include_scopes]
+          # if there are no specified scopes to include, include all of them
+          unless scopes_to_include.empty?
+            # if this commit does not have a scope, skip when bumping versions
+            next if commit[:scope].nil?
+            # if it is, we'll include this commit when bumping versions
+            next unless scopes_to_include.include?(scope)
+          end
+
           if commit[:release] == "major" || commit[:is_breaking_change]
             next_major += 1
             next_minor = 0
@@ -192,7 +201,7 @@ module Fastlane
       end
 
       def self.is_codepush_friendly(params)
-        git_command = "git rev-list --max-parents=0 HEAD -- #{Dir.pwd}"
+        git_command = "git rev-list --max-parents=0 HEAD"
         # Begining of the branch is taken for codepush analysis
         hash_lines = Actions.sh("#{git_command} | wc -l", log: params[:debug]).chomp
         hash = Actions.sh(git_command, log: params[:debug]).chomp
@@ -322,6 +331,13 @@ module Fastlane
             description: "Prevent tag from falling back to vX.Y.Z when there is no match",
             default_value: false,
             type: Boolean,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :include_scopes,
+            description: "Only allow commits with certain scopes when calculating releases",
+            default_value: [],
+            type: Array,
             optional: true
           ),
           FastlaneCore::ConfigItem.new(

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -61,9 +61,11 @@ module Fastlane
             }
           end
 
-          # neighter matched tag and first hash could be used - as fallback we try vX.Y.Z
-          UI.message("It couldn't match tag for #{params[:match]} and couldn't use first commit. Check if tag vX.Y.Z can be taken as a begining of next release")
-          tag = get_last_tag(match: "v*", debug: params[:debug])
+          unless params[:prevent_tag_fallback]
+            # neither matched tag and first hash could be used - as fallback we try vX.Y.Z
+            UI.message("It couldn't match tag for #{params[:match]} and couldn't use first commit. Check if tag vX.Y.Z can be taken as a begining of next release")
+            tag = get_last_tag(match: "v*", debug: params[:debug])
+          end
 
           # even fallback tag doesn't work
           if tag.empty?
@@ -314,6 +316,13 @@ module Fastlane
             key: :tag_version_match,
             description: "To parse version number from tag name",
             default_value: '\d+\.\d+\.\d+'
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :prevent_tag_fallback,
+            description: "Prevent tag from falling back to vX.Y.Z when there is no match",
+            default_value: false,
+            type: Boolean,
+            optional: true
           ),
           FastlaneCore::ConfigItem.new(
             key: :ignore_scopes,

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -28,7 +28,7 @@ module Fastlane
       end
 
       def self.get_last_tag_hash(params)
-        command = "git rev-list -n 1 refs/tags/#{params[:tag_name]} -- #{Dir.pwd}"
+        command = "git rev-list -n 1 refs/tags/#{params[:tag_name]}"
         Actions.sh(command, log: params[:debug]).chomp
       end
 
@@ -43,7 +43,7 @@ module Fastlane
 
       def self.get_beginning_of_next_sprint(params)
         # command to get first commit
-        git_command = "git rev-list --max-parents=0 HEAD -- #{Dir.pwd}"
+        git_command = "git rev-list --max-parents=0 HEAD"
 
         tag = get_last_tag(match: params[:match], debug: params[:debug])
 
@@ -190,7 +190,7 @@ module Fastlane
       end
 
       def self.is_codepush_friendly(params)
-        git_command = "git rev-list --max-parents=0 HEAD -- #{Dir.pwd}"
+        git_command = "git rev-list --max-parents=0 HEAD"
         # Begining of the branch is taken for codepush analysis
         hash_lines = Actions.sh("#{git_command} | wc -l", log: params[:debug]).chomp
         hash = Actions.sh(git_command, log: params[:debug]).chomp

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -28,7 +28,7 @@ module Fastlane
       end
 
       def self.get_last_tag_hash(params)
-        command = "git rev-list -n 1 refs/tags/#{params[:tag_name]}"
+        command = "git rev-list -n 1 refs/tags/#{params[:tag_name]} -- #{Dir.pwd}"
         Actions.sh(command, log: params[:debug]).chomp
       end
 
@@ -43,7 +43,7 @@ module Fastlane
 
       def self.get_beginning_of_next_sprint(params)
         # command to get first commit
-        git_command = 'git rev-list --max-parents=0 HEAD'
+        git_command = "git rev-list --max-parents=0 HEAD -- #{Dir.pwd}"
 
         tag = get_last_tag(match: params[:match], debug: params[:debug])
 
@@ -190,7 +190,7 @@ module Fastlane
       end
 
       def self.is_codepush_friendly(params)
-        git_command = 'git rev-list --max-parents=0 HEAD'
+        git_command = "git rev-list --max-parents=0 HEAD -- #{Dir.pwd}"
         # Begining of the branch is taken for codepush analysis
         hash_lines = Actions.sh("#{git_command} | wc -l", log: params[:debug]).chomp
         hash = Actions.sh(git_command, log: params[:debug]).chomp

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -28,7 +28,7 @@ module Fastlane
       end
 
       def self.get_last_tag_hash(params)
-        command = "git rev-list -n 1 refs/tags/#{params[:tag_name]}"
+        command = "git rev-list -n 1 refs/tags/#{params[:tag_name]} -- #{Dir.pwd}"
         Actions.sh(command, log: params[:debug]).chomp
       end
 
@@ -43,7 +43,7 @@ module Fastlane
 
       def self.get_beginning_of_next_sprint(params)
         # command to get first commit
-        git_command = "git rev-list --max-parents=0 HEAD"
+        git_command = "git rev-list --max-parents=0 HEAD -- #{Dir.pwd}"
 
         tag = get_last_tag(match: params[:match], debug: params[:debug])
 
@@ -190,7 +190,7 @@ module Fastlane
       end
 
       def self.is_codepush_friendly(params)
-        git_command = "git rev-list --max-parents=0 HEAD"
+        git_command = "git rev-list --max-parents=0 HEAD -- #{Dir.pwd}"
         # Begining of the branch is taken for codepush analysis
         hash_lines = Actions.sh("#{git_command} | wc -l", log: params[:debug]).chomp
         hash = Actions.sh(git_command, log: params[:debug]).chomp

--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -97,20 +97,6 @@ module Fastlane
         }
       end
 
-      def self.should_exclude_commit(params)
-        commit_scope = params[:commit_scope]
-        scopes_to_include = params[:include_scopes]
-        scopes_to_ignore = params[:ignore_scopes]
-
-        unless scopes_to_include.empty?
-          return !scopes_to_include.include?(commit_scope)
-        end
-
-        unless commit_scope.nil?
-          return scopes_to_ignore.include?(commit_scope)
-        end
-      end
-
       def self.is_releasable(params)
         # Hash of the commit where is the last version
         beginning = get_beginning_of_next_sprint(params)
@@ -156,7 +142,7 @@ module Fastlane
             pattern: format_pattern
           )
 
-          next if should_exclude_commit(
+          next if Helper::SemanticReleaseHelper.should_exclude_commit(
             commit_scope: commit[:scope],
             include_scopes: params[:include_scopes],
             ignore_scopes: params[:ignore_scopes]

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -282,6 +282,13 @@ module Fastlane
             optional: true
           ),
           FastlaneCore::ConfigItem.new(
+            key: :include_scopes,
+            description: "To only include certain scopes when calculating releases",
+            default_value: [],
+            type: Array,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
             key: :ignore_scopes,
             description: "To ignore certain scopes when calculating releases",
             default_value: [],

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -185,13 +185,11 @@ module Fastlane
             pattern: format_pattern
           )
 
-          unless commit[:scope].nil?
-            # if this commit has a scope, then we need to inspect to see if that is one of the scopes we're trying to exclude
-            scope = commit[:scope]
-            scopes_to_ignore = params[:ignore_scopes]
-            # if it is, we'll skip this commit when bumping versions
-            next if scopes_to_ignore.include?(scope) #=> true
-          end
+          next if Helper::SemanticReleaseHelper.should_exclude_commit(
+            commit_scope: commit[:scope],
+            include_scopes: params[:include_scopes],
+            ignore_scopes: params[:ignore_scopes]
+          )
 
           commit[:hash] = splitted[2]
           commit[:short_hash] = splitted[3]

--- a/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
+++ b/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
@@ -16,7 +16,7 @@ module Fastlane
       # as `Helper::SemanticReleaseHelper.your_method`
       #
       def self.git_log(params)
-        command = "git log --pretty='#{params[:pretty]}' --reverse #{params[:start]}..HEAD"
+        command = "git log --pretty='#{params[:pretty]}' --reverse #{params[:start]}..HEAD -- #{Dir.pwd}"
         Actions.sh(command, log: params[:debug]).chomp
       end
 

--- a/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
+++ b/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
@@ -20,6 +20,20 @@ module Fastlane
         Actions.sh(command, log: params[:debug]).chomp
       end
 
+      def self.should_exclude_commit(params)
+        commit_scope = params[:commit_scope]
+        scopes_to_include = params[:include_scopes]
+        scopes_to_ignore = params[:ignore_scopes]
+
+        unless scopes_to_include.empty?
+          return !scopes_to_include.include?(commit_scope)
+        end
+
+        unless commit_scope.nil?
+          return scopes_to_ignore.include?(commit_scope)
+        end
+      end
+
       def self.parse_commit(params)
         commit_subject = params[:commit_subject].strip
         commit_body = params[:commit_body]

--- a/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
+++ b/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
@@ -16,7 +16,7 @@ module Fastlane
       # as `Helper::SemanticReleaseHelper.your_method`
       #
       def self.git_log(params)
-        command = "git log --pretty='#{params[:pretty]}' --reverse #{params[:start]}..HEAD -- #{Dir.pwd}"
+        command = "git log --pretty='#{params[:pretty]}' --reverse #{params[:start]}..HEAD"
         Actions.sh(command, log: params[:debug]).chomp
       end
 

--- a/spec/analyze_commits_spec.rb
+++ b/spec/analyze_commits_spec.rb
@@ -89,6 +89,13 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
           expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.2.1")
         end
 
+        it "should accommodate an empty include_scopes array" do
+          test_analyze_commits(commits)
+
+          expect(execute_lane_test(match: 'v*', include_scopes: [])).to eq(true)
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.2.1")
+        end
+
         it "should skip a single scopes if it has been added to ignore_scopes" do
           test_analyze_commits(commits)
 
@@ -110,6 +117,30 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
           test_analyze_commits(commits)
 
           expect(execute_lane_test(match: 'v*', ignore_scopes: ['ios'])).to eq(false)
+        end
+
+        it "should only include scopes specified in include_scopes array" do
+          commits = [
+            "fix(scope): ...|",
+            "feat(ios): ...|",
+            "fix(ios): ...|",
+            "feat(android): ...|",
+            "feat(web): ...|",
+            "feat(mobile): ...|"
+          ]
+          test_analyze_commits(commits)
+
+          expect(execute_lane_test(match: 'v*', include_scopes: ['android', 'ios', 'mobile'])).to eq(true)
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.3.0")
+        end
+
+        it "should not pass analysis checks if all commits are not in the included scopes" do
+          commits = [
+            "fix(ios): ...|"
+          ]
+          test_analyze_commits(commits)
+
+          expect(execute_lane_test(match: 'v*', include_scopes: ['android'])).to eq(false)
         end
       end
     end


### PR DESCRIPTION
I currently have a react native project within a monorepo that also contains the api and web app.

Therefore fetching the git history specific to the react native directory is required for this plugin to work effectively. I don't imagine any issues from this change however @xotahal would love to get your input on the approach and if you perhaps have a better idea on how to achieve this.