### PR TITLE
fix: running strip on a potentially missing subject

### DIFF
--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -132,7 +132,7 @@ module Fastlane
         format_pattern = lane_context[SharedValues::CONVENTIONAL_CHANGELOG_ACTION_FORMAT_PATTERN]
         splitted.each do |line|
           parts = line.split("|")
-          subject = parts[0].strip
+          subject = "#{parts[0]}".strip
           # conventional commits are in format
           # type: subject (fix: app crash - for example)
           commit = Helper::SemanticReleaseHelper.parse_commit(

--- a/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
+++ b/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
@@ -35,7 +35,7 @@ module Fastlane
       end
 
       def self.parse_commit(params)
-        commit_subject = params[:commit_subject].strip
+        commit_subject = "#{params[:commit_subject]}".strip
         commit_body = params[:commit_body]
         releases = params[:releases]
         codepush_friendly = params[:codepush_friendly]


### PR DESCRIPTION
Hi,

I am currently using this in a mono repo and since not everyone uses conventional commits there might not be a subject to strip from which results in running `strip` on a nil value causing a crash to occur. 

It's odd because this error only recently started occurring even though we have been using this plugin for over 9 months to handle deployments but this is the only viable way I could see of fixing it, let me know if this seems logical to you or not. The only alternative I could see is if `should_exclude_commit` was run before the subject was extracted.