### PR TITLE
fix: last tag being current commit

### DIFF
--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -75,7 +75,11 @@ module Fastlane
 
         # Tag's format is v2.3.4-5-g7685948
         # See git describe man page for more info
-        tag_name = tag.split('-')[0...-2].join('-').strip
+        # It can be also v2.3.4-5 if there is no commit after tag
+        tag_name = tag
+        if tag.split('-').length >= 3
+          tag_name = tag.split('-')[0...-2].join('-').strip
+        end
         parsed_version = tag_name.match(params[:tag_version_match])
 
         if parsed_version.nil?

--- a/spec/analyze_commits_spec.rb
+++ b/spec/analyze_commits_spec.rb
@@ -12,7 +12,7 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
       allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
     end
 
-    def test_analyze_commits_same_commit_as_tag()
+    def test_analyze_commits_same_commit_as_tag
       # for simplicity, these two actions are grouped together because they need to be run for every test,
       # but require different commits to be passed each time. So we can't use the "before :each" for this
       # this is the same as test_analyze_commits, but the last commit is the same as the last tag
@@ -174,13 +174,13 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
       expect(execute_lane_test(match: 'v*')).to eq(false)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.8")
     end
-  
+
     it "should return false when we are on the same commit as the last tag" do
       commits = [
         "Merge ...|",
         "Custom ...|"
       ]
-      test_analyze_commits_same_commit_as_tag()
+      test_analyze_commits_same_commit_as_tag
 
       expect(execute_lane_test(match: 'v*')).to eq(false)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.8")

--- a/spec/analyze_commits_spec.rb
+++ b/spec/analyze_commits_spec.rb
@@ -12,6 +12,13 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
       allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_commits_from_hash).and_return(commits)
     end
 
+    def test_analyze_commits_same_commit_as_tag()
+      # for simplicity, these two actions are grouped together because they need to be run for every test,
+      # but require different commits to be passed each time. So we can't use the "before :each" for this
+      # this is the same as test_analyze_commits, but the last commit is the same as the last tag
+      allow(Fastlane::Actions::AnalyzeCommitsAction).to receive(:get_last_tag).and_return('v1.0.8')
+    end
+
     def execute_lane_test(params)
       Fastlane::FastFile.new.parse("lane :test do analyze_commits( #{params} ) end").runner.execute(:test)
     end
@@ -163,6 +170,17 @@ describe Fastlane::Actions::AnalyzeCommitsAction do
         "Custom ...|"
       ]
       test_analyze_commits(commits)
+
+      expect(execute_lane_test(match: 'v*')).to eq(false)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.8")
+    end
+  
+    it "should return false when we are on the same commit as the last tag" do
+      commits = [
+        "Merge ...|",
+        "Custom ...|"
+      ]
+      test_analyze_commits_same_commit_as_tag()
 
       expect(execute_lane_test(match: 'v*')).to eq(false)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::RELEASE_NEXT_VERSION]).to eq("1.0.8")


### PR DESCRIPTION
This fixes an issue when the last tag is the current commit.

It threw an error like this: `Error while parsing version from tag  by using tag_version_match - \d+\.\d+\.\d+. Please check if the tag contains version as you expect and if you are using single brackets for tag_version_match parameter.`

It instead should parse the version and carry on.