### PR TITLE
feat: support multiple scopes and `display_scopes` option

### DIFF
--- a/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/analyze_commits.rb
@@ -147,7 +147,7 @@ module Fastlane
           )
 
           next if Helper::SemanticReleaseHelper.should_exclude_commit(
-            commit_scope: commit[:scope],
+            commit_scopes: commit[:scopes],
             include_scopes: params[:include_scopes],
             ignore_scopes: params[:ignore_scopes]
           )

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -72,9 +72,11 @@ module Fastlane
 
             result += "-"
 
-            unless commit[:scope].nil?
-              formatted_text = style_text("#{commit[:scope]}:", format, "bold").to_s
-              result += " #{formatted_text}"
+            if params[:display_scopes] == true
+              unless commit[:scopes].nil? || commit[:scopes].empty? 
+                formatted_text = style_text("#{commit[:scopes].join(", ")}:", format, "bold").to_s
+                result += " #{formatted_text}"
+              end
             end
 
             result += " #{commit[:subject]}"
@@ -186,7 +188,7 @@ module Fastlane
           )
 
           next if Helper::SemanticReleaseHelper.should_exclude_commit(
-            commit_scope: commit[:scope],
+            commit_scopes: commit[:scopes],
             include_scopes: params[:include_scopes],
             ignore_scopes: params[:ignore_scopes]
           )
@@ -275,6 +277,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :display_links,
             description: "Whether you want to display the links to commit IDs",
+            default_value: true,
+            type: Boolean,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :display_scopes,
+            description: "Whether you want to display the scopes",
             default_value: true,
             type: Boolean,
             optional: true

--- a/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
+++ b/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
@@ -21,16 +21,14 @@ module Fastlane
       end
 
       def self.should_exclude_commit(params)
-        commit_scope = params[:commit_scope]
+        commit_scopes = params[:commit_scopes]
         scopes_to_include = params[:include_scopes]
         scopes_to_ignore = params[:ignore_scopes]
-
-        unless scopes_to_include.empty?
-          return !scopes_to_include.include?(commit_scope)
-        end
-
-        unless commit_scope.nil?
-          return scopes_to_ignore.include?(commit_scope)
+        unless commit_scopes.nil? || commit_scopes.empty?
+          unless scopes_to_include.empty?
+            return (scopes_to_include & commit_scopes).empty?
+          end
+          return !(scopes_to_ignore & commit_scopes).empty?
         end
       end
 
@@ -53,11 +51,11 @@ module Fastlane
 
         unless matched.nil?
           type = matched[1]
-          scope = matched[2]
+          scopes = matched[2].nil? ? nil : matched[2].split(",")
 
           result[:is_valid] = true
           result[:type] = type
-          result[:scope] = scope
+          result[:scopes] = scopes
           result[:has_exclamation_mark] = matched[3] == '!'
           result[:subject] = matched[4]
 


### PR DESCRIPTION
This PR adds support for multiple scopes are per conventional-commit specs.
I split using "," then for display i join using ", ".
I also added `display_scopes` to disable displaying of scopes in the changelog