### PR TITLE
Allow to group commits by scope

### DIFF
--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -1,5 +1,6 @@
 require 'fastlane/action'
 require_relative '../helper/semantic_release_helper'
+require 'pry'
 
 module Fastlane
   module Actions
@@ -147,12 +148,10 @@ module Fastlane
           result += style_text(sections[type.to_sym], format, "heading").to_s
           result += "\n"
 
-          commits_by_scope = commits_in_type.group_by { |c| c[:scope].strip }
+          commits_by_scope = commits_in_type.group_by { |c| c[:scope]&.strip || sections[:no_type] }
           commits_by_scope.each do |scope, commits_in_scope|
-            unless scope.nil?
-              formatted_text = style_text("#{scope}:", format, "bold").to_s
-              result += "#{formatted_text}"
-            end
+            subtitle = style_text("#{scope}:", format, "bold").to_s
+            result += "#{subtitle}"
 
             is_single_commit = commits_in_scope.size == 1
             commits_in_scope.each do |commit|

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -132,11 +132,10 @@ module Fastlane
 
       def self.note_builder_grouped(format, commits, version, commit_url, params)
         sections = params[:sections]
-        result = ""
+        lines = []
 
         if params[:display_title] == true
-          result += build_title(version, params)
-          result += "\n\n"
+          sections < build_title(version, params)
         end
 
         commits_by_type = commits.group_by { |c| c[:type] }
@@ -144,31 +143,24 @@ module Fastlane
           commits_in_type = commits_by_type[type]
           next if commits_in_type.nil? || commits_in_type.size == 0
 
-          result += style_text_grouped(sections[type.to_sym], format, "heading").to_s
-          result += "\n"
+          text = style_text_grouped(sections[type.to_sym], format, "heading").to_s
+          lines < text
 
           commits_by_scope = commits_in_type.group_by { |c| c[:scope]&.strip || sections[:no_type] }
           commits_by_scope.each do |scope, commits_in_scope|
             subtitle = style_text_grouped("#{scope}:", format, "bold").to_s
-            result += "#{subtitle}"
+            lines < "#{subtitle}"
 
             is_single_commit = commits_in_scope.size == 1
             commits_in_scope.each do |commit|
               next if commit[:is_merge]
 
-              result += build_commit_grouped(params, commit, is_single_commit)
+              lines < build_commit_grouped(params, commit, is_single_commit)
             end
-
-            result += "\n"
           end
-
-          result += "\n"
         end
 
-        # Trim any trailing newlines
-        result = result.rstrip!
-
-        result
+        sections.join("\n")
       end
 
       def self.build_commit(params, commit, is_single_commit)

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -294,7 +294,14 @@ module Fastlane
             default_value: false,
             type: Boolean,
             optional: true
-          )
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :group_by_scope,
+            description: "True if you want to group multiple changes by scope name",
+            default_value: false,
+            type: Boolean,
+            optional: true
+          ),
         ]
       end
 

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -1,6 +1,5 @@
 require 'fastlane/action'
 require_relative '../helper/semantic_release_helper'
-require 'pry'
 
 module Fastlane
   module Actions

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -1,4 +1,7 @@
 require 'spec_helper'
+require 'pry'
+
+
 
 describe Fastlane::Actions::ConventionalChangelogAction do
   HASH_MARKDOWN = "([short_hash](/long_hash))"
@@ -320,21 +323,20 @@ describe Fastlane::Actions::ConventionalChangelogAction do
                             "- **Scope 1:**\n"\
                             "   - Add a new feature #{HASH_MARKDOWN}\n"\
                             "   - Add another feature #{HASH_MARKDOWN}\n"\
-                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}\n"
+                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}"
 
 
           result = execute_lane_test(group_by_scope: true)
-
           expect(result).to eq(expected_result)
         end
 
         it "should group in Scope 1 multiple commits in plain format" do
           expected_result = "1.0.2 (2019-05-25)\n\n"\
                             "Features:\n"\
-                            "- Scope 2: Add one more feature #{HASH_PLAIN}"
                             "- Scope 1:\n"\
                             "   - Add a new feature #{HASH_PLAIN}\n"\
                             "   - Add another feature #{HASH_PLAIN}\n"\
+                            "- Scope 2: Add one more feature #{HASH_PLAIN}"
 
           result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -378,13 +380,16 @@ describe Fastlane::Actions::ConventionalChangelogAction do
                             "   - Add another feature #{HASH_MARKDOWN}\n"\
                             "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}\n"\
                             "### Bug fixes\n"\
-                            "- **Scope 2:** Add 1 more feature #{HASH_MARKDOWN}"\
+                            "- **Scope 2:** Add 1 more feature #{HASH_MARKDOWN}\n"\
                             "- **Scope 1:**\n"\
                             "   - Add 2 more feature #{HASH_MARKDOWN}\n"\
-                            "   - Add 3 more feature #{HASH_MARKDOWN}\n"\
+                            "   - Add 3 more feature #{HASH_MARKDOWN}"\
 
 
           result = execute_lane_test(group_by_scope: true)
+          puts "RESULT #{result}\n"
+          puts "expected_result #{result}\n"
+
           expect(result).to eq(expected_result)
         end
       end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 require 'pry'
 
-
-
 describe Fastlane::Actions::ConventionalChangelogAction do
   HASH_MARKDOWN = "([short_hash](/long_hash))"
   HASH_PLAIN = "(/long_hash)"
@@ -310,7 +308,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
           commits = [
             commit(type: 'feat', scope: 'Scope 1', title: 'Add a new feature'),
             commit(type: 'feat', scope: 'Scope 1', title: 'Add another feature'),
-            commit(type: 'feat', scope: 'Scope 2', title: 'Add one more feature'),
+            commit(type: 'feat', scope: 'Scope 2', title: 'Add one more feature')
           ]
 
           allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
@@ -325,8 +323,8 @@ describe Fastlane::Actions::ConventionalChangelogAction do
                             "   - Add another feature #{HASH_MARKDOWN}\n"\
                             "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}"
 
-
           result = execute_lane_test(group_by_scope: true)
+
           expect(result).to eq(expected_result)
         end
 
@@ -398,7 +396,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
             commit(type: 'feat', scope: 'Same Scope', title: 'Add a new feature with scope'),
             commit(type: 'feat', title: 'Add a new feature 3'),
             commit(type: 'feat', scope: 'Same Scope', title: 'Add a new feature with scope 2'),
-            commit(type: 'feat', title: 'Add another feature'),
+            commit(type: 'feat', title: 'Add another feature')
           ]
 
           allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::ConventionalChangelogAction do
+  def commit(type, scope, message, author="Jiri Otahal")
+    "#{type}(#{scope}): #{message}|long_hash|short_hash|#{author}|time"
+  end
+
   describe "Conventional Changelog" do
     before do
       Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::CONVENTIONAL_CHANGELOG_ACTION_FORMAT_PATTERN] = Fastlane::Helper::SemanticReleaseHelper.format_patterns["default"]
@@ -287,6 +291,119 @@ describe Fastlane::Actions::ConventionalChangelogAction do
     end
 
     after do
+    end
+
+    describe 'group messages if group_by_scope is true' do
+      before do
+        commits = [
+          commit('feat', 'Scope 1', 'Add a new feature'),
+          commit('feat', 'Scope 1', 'Add another feature'),
+          commit('feat', 'Scope 2', 'Add one more feature')
+        ]
+
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+      end
+
+      it "should hide in markdown format" do
+        expected_result = """### Bug fixes
+        - Scope 1:
+           - Add a new feature([short_hash](/long_hash))
+           - Add another feature([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true)
+
+        expect(result).to eq(expected_result)
+      end
+
+      it "should hide in plain format" do
+        expected_result = """Bug fixes
+        - Scope 1:
+           - Add a new feature ([short_hash](/long_hash))
+           - Add another feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more ([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true, format: 'plain')
+
+        expect(result).to eq(expected_result)
+      end
+
+      it "should hide in slack format" do
+        expected_result = """* Bug fixes *
+        - Scope 1:
+           - Add a new feature ([short_hash](/long_hash))
+           - Add another feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more ([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true, format: 'slack')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    describe 'dont group messages if group_by_scope is false' do
+      before do
+        commits = [
+          commit('feat', 'Scope 1', 'Add a new feature'),
+          commit('feat', 'Scope 1', 'Add another feature'),
+          commit('feat', 'Scope 2', 'Add one more feature')
+        ]
+
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+      end
+
+      it "should hide in markdown format" do
+        expected_result = """### Bug fixes
+        - Scope 1:
+           - Add a new feature([short_hash](/long_hash))
+        - Scope 1:
+           - Add another feature([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true)
+
+        expect(result).to eq(expected_result)
+      end
+
+      it "should hide in plain format" do
+        expected_result = """Bug fixes
+        - Scope 1:
+           - Add a new feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add another feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more ([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true, format: 'plain')
+
+        expect(result).to eq(expected_result)
+      end
+
+      it "should hide in slack format" do
+        expected_result = """* Bug fixes *
+        - Scope 1:
+           - Add a new feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add another feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more ([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true, format: 'slack')
+
+        expect(result).to eq(expected_result)
+      end
     end
   end
 end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::ConventionalChangelogAction do
-  def commit(type, scope, message, author="Jiri Otahal")
-    "#{type}(#{scope}): #{message}|long_hash|short_hash|#{author}|time"
+  def commit(type, scope, sub, body='', author="Jiri Otahal")
+    "#{type}(#{scope}): #{sub}|#{body}|long_hash|short_hash|#{author}|time"
   end
 
   describe "Conventional Changelog" do
@@ -306,11 +306,13 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       end
 
       it "should hide in markdown format" do
-        expected_result = """### Bug fixes
-- Scope 1:
-   - Add a new feature([short_hash](/long_hash))
-   - Add another feature([short_hash](/long_hash))
-- Scope 1: Add one more([short_hash](/long_hash))"""
+        expected_result = """# 1.0.2 (2019-05-25)
+
+### Features
+**Scope 1:**
+   - Add a new feature ([short_hash](/long_hash))
+   - Add another feature ([short_hash](/long_hash))
+**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true)
 
@@ -318,11 +320,13 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       end
 
       it "should hide in plain format" do
-        expected_result = """Bug fixes
-- Scope 1:
+        expected_result = """# 1.0.2 (2019-05-25)
+
+Features
+**Scope 1:**
    - Add a new feature ([short_hash](/long_hash))
    - Add another feature ([short_hash](/long_hash))
-- Scope 1: Add one more ([short_hash](/long_hash))"""
+**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -330,11 +334,13 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       end
 
       it "should hide in slack format" do
-        expected_result = """* Bug fixes *
-- Scope 1:
+        expected_result = """# 1.0.2 (2019-05-25)
+
+* Features *
+**Scope 1:**
    - Add a new feature ([short_hash](/long_hash))
    - Add another feature ([short_hash](/long_hash))
-- Scope 1: Add one more ([short_hash](/long_hash))"""
+**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true, format: 'slack')
 

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -387,8 +387,6 @@ describe Fastlane::Actions::ConventionalChangelogAction do
 
 
           result = execute_lane_test(group_by_scope: true)
-          puts "RESULT #{result}\n"
-          puts "expected_result #{result}\n"
 
           expect(result).to eq(expected_result)
         end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -307,7 +307,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
           commits = [
             commit(type: 'feat', scope: 'Scope 1', title: 'Add a new feature'),
             commit(type: 'feat', scope: 'Scope 1', title: 'Add another feature'),
-            commit(type: 'feat', scope: 'Scope 2', title: 'Add one more feature')
+            commit(type: 'feat', scope: 'Scope 2', title: 'Add one more feature'),
           ]
 
           allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
@@ -320,7 +320,8 @@ describe Fastlane::Actions::ConventionalChangelogAction do
                             "- **Scope 1:**\n"\
                             "   - Add a new feature #{HASH_MARKDOWN}\n"\
                             "   - Add another feature #{HASH_MARKDOWN}\n"\
-                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}"
+                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}\n"
+
 
           result = execute_lane_test(group_by_scope: true)
 
@@ -330,10 +331,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in plain format" do
           expected_result = "1.0.2 (2019-05-25)\n\n"\
                             "Features:\n"\
+                            "- Scope 2: Add one more feature #{HASH_PLAIN}"
                             "- Scope 1:\n"\
                             "   - Add a new feature #{HASH_PLAIN}\n"\
                             "   - Add another feature #{HASH_PLAIN}\n"\
-                            "- Scope 2: Add one more feature #{HASH_PLAIN}"
 
           result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -350,6 +351,40 @@ describe Fastlane::Actions::ConventionalChangelogAction do
 
           result = execute_lane_test(group_by_scope: true, format: 'slack')
 
+          expect(result).to eq(expected_result)
+        end
+      end
+
+      context "having scopes and  multiple commits with different types" do
+        before do
+          commits = [
+            commit(type: 'feat', scope: 'Scope 1', title: 'Add a new feature'),
+            commit(type: 'feat', scope: 'Scope 1', title: 'Add another feature'),
+            commit(type: 'feat', scope: 'Scope 2', title: 'Add one more feature'),
+            commit(type: 'fix', scope: 'Scope 2', title: 'Add 1 more feature'),
+            commit(type: 'fix', scope: 'Scope 1', title: 'Add 2 more feature'),
+            commit(type: 'fix', scope: 'Scope 1', title: 'Add 3 more feature')
+          ]
+
+          allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+          allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+        end
+
+        it "should group by type and then by scope" do
+          expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                            "### Features\n"\
+                            "- **Scope 1:**\n"\
+                            "   - Add a new feature #{HASH_MARKDOWN}\n"\
+                            "   - Add another feature #{HASH_MARKDOWN}\n"\
+                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}\n"\
+                            "### Bug fixes\n"\
+                            "- **Scope 2:** Add 1 more feature #{HASH_MARKDOWN}"\
+                            "- **Scope 1:**\n"\
+                            "   - Add 2 more feature #{HASH_MARKDOWN}\n"\
+                            "   - Add 3 more feature #{HASH_MARKDOWN}\n"\
+
+
+          result = execute_lane_test(group_by_scope: true)
           expect(result).to eq(expected_result)
         end
       end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -317,10 +317,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in markdown format" do
           expected_result = "# 1.0.2 (2019-05-25)\n\n"\
                             "### Features\n"\
-                            "**Scope 1:**\n"\
+                            "- **Scope 1:**\n"\
                             "   - Add a new feature #{HASH_MARKDOWN}\n"\
                             "   - Add another feature #{HASH_MARKDOWN}\n"\
-                            "**Scope 2:** Add one more feature #{HASH_MARKDOWN}"
+                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}"
 
           result = execute_lane_test(group_by_scope: true)
 
@@ -330,10 +330,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in plain format" do
           expected_result = "1.0.2 (2019-05-25)\n\n"\
                             "Features:\n"\
-                            "Scope 1:\n"\
+                            "- Scope 1:\n"\
                             "   - Add a new feature #{HASH_PLAIN}\n"\
                             "   - Add another feature #{HASH_PLAIN}\n"\
-                            "Scope 2: Add one more feature #{HASH_PLAIN}"
+                            "- Scope 2: Add one more feature #{HASH_PLAIN}"
 
           result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -343,10 +343,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in slack format" do
           expected_result = "*1.0.2 (2019-05-25)*\n\n"\
                             "*Features*\n"\
-                            "*Scope 1:*\n"\
-                            "   - Add a new feature #{HASH_SLACK}\n"\
-                            "   - Add another feature #{HASH_SLACK}\n"\
-                            "*Scope 2:* Add one more feature #{HASH_SLACK}"
+                            "- *Scope 1:*\n"\
+                            "    - Add a new feature #{HASH_SLACK}\n"\
+                            "    - Add another feature #{HASH_SLACK}\n"\
+                            "- *Scope 2:* Add one more feature #{HASH_SLACK}"
 
           result = execute_lane_test(group_by_scope: true, format: 'slack')
 
@@ -370,10 +370,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group multiple commits without scope inside 'Other work' in markdown format" do
           expected_result = "# 1.0.2 (2019-05-25)\n\n"\
                             "### Features\n"\
-                            "**Same Scope:**\n"\
+                            "- **Same Scope:**\n"\
                             "   - Add a new feature with scope #{HASH_MARKDOWN}\n"\
                             "   - Add a new feature with scope 2 #{HASH_MARKDOWN}\n"\
-                            "**Other work:**\n"\
+                            "- **Other work:**\n"\
                             "   - Add a new feature 3 #{HASH_MARKDOWN}\n"\
                             "   - Add another feature #{HASH_MARKDOWN}"
 
@@ -385,10 +385,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in plain format" do
           expected_result = "1.0.2 (2019-05-25)\n\n"\
                             "Features:\n"\
-                            "Same Scope:\n"\
+                            "- Same Scope:\n"\
                             "   - Add a new feature with scope #{HASH_PLAIN}\n"\
                             "   - Add a new feature with scope 2 #{HASH_PLAIN}\n"\
-                            "Other work:\n"\
+                            "- Other work:\n"\
                             "   - Add a new feature 3 #{HASH_PLAIN}\n"\
                             "   - Add another feature #{HASH_PLAIN}"
 
@@ -400,12 +400,12 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in slack format" do
           expected_result = "*1.0.2 (2019-05-25)*\n\n"\
                             "*Features*\n"\
-                            "*Same Scope:*\n"\
-                            "   - Add a new feature with scope #{HASH_SLACK}\n"\
-                            "   - Add a new feature with scope 2 #{HASH_SLACK}\n"\
-                            "*Other work:*\n"\
-                            "   - Add a new feature 3 #{HASH_SLACK}\n"\
-                            "   - Add another feature #{HASH_SLACK}"
+                            "- *Same Scope:*\n"\
+                            "    - Add a new feature with scope #{HASH_SLACK}\n"\
+                            "    - Add a new feature with scope 2 #{HASH_SLACK}\n"\
+                            "- *Other work:*\n"\
+                            "    - Add a new feature 3 #{HASH_SLACK}\n"\
+                            "    - Add another feature #{HASH_SLACK}"
 
           result = execute_lane_test(group_by_scope: true, format: 'slack')
 

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -305,42 +305,39 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
       end
 
-      it "should hide in markdown format" do
-        expected_result = """# 1.0.2 (2019-05-25)
-
-### Features
-**Scope 1:**
-   - Add a new feature ([short_hash](/long_hash))
-   - Add another feature ([short_hash](/long_hash))
-**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
+      it "should group in Scope 1 multiple commits in markdown format" do
+        expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                          "### Features\n"\
+                          "**Scope 1:**\n"\
+                          "   - Add a new feature ([short_hash](/long_hash))\n"\
+                          "   - Add another feature ([short_hash](/long_hash))\n"\
+                          "**Scope 2:** Add one more feature ([short_hash](/long_hash))"
 
         result = execute_lane_test(group_by_scope: true)
 
         expect(result).to eq(expected_result)
       end
 
-      it "should hide in plain format" do
-        expected_result = """1.0.2 (2019-05-25)
-
-Features:
-Scope 1:
-   - Add a new feature (/long_hash)
-   - Add another feature (/long_hash)
-Scope 2: Add one more feature (/long_hash)"""
+      it "should group in Scope 1 multiple commits in plain format" do
+        expected_result = "1.0.2 (2019-05-25)\n\n"\
+                          "Features:\n"\
+                          "Scope 1:\n"\
+                          "   - Add a new feature (/long_hash)\n"\
+                          "   - Add another feature (/long_hash)\n"\
+                          "Scope 2: Add one more feature (/long_hash)"
 
         result = execute_lane_test(group_by_scope: true, format: 'plain')
 
         expect(result).to eq(expected_result)
       end
 
-      it "should hide in slack format" do
-        expected_result = """*1.0.2 (2019-05-25)*
-
-*Features*
-*Scope 1:*
-   - Add a new feature (</long_hash|short_hash>)
-   - Add another feature (</long_hash|short_hash>)
-*Scope 2:* Add one more feature (</long_hash|short_hash>)"""
+      it "should group in Scope 1 multiple commits in slack format" do
+        expected_result = "*1.0.2 (2019-05-25)*\n\n"\
+                          "*Features*\n"\
+                          "*Scope 1:*\n"\
+                          "   - Add a new feature (</long_hash|short_hash>)\n"\
+                          "   - Add another feature (</long_hash|short_hash>)\n"\
+                          "*Scope 2:* Add one more feature (</long_hash|short_hash>)"
 
         result = execute_lane_test(group_by_scope: true, format: 'slack')
 

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -320,13 +320,13 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       end
 
       it "should hide in plain format" do
-        expected_result = """# 1.0.2 (2019-05-25)
+        expected_result = """1.0.2 (2019-05-25)
 
-Features
-**Scope 1:**
-   - Add a new feature ([short_hash](/long_hash))
-   - Add another feature ([short_hash](/long_hash))
-**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
+Features:
+Scope 1:
+   - Add a new feature (/long_hash)
+   - Add another feature (/long_hash)
+Scope 2: Add one more feature (/long_hash)"""
 
         result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -334,13 +334,13 @@ Features
       end
 
       it "should hide in slack format" do
-        expected_result = """# 1.0.2 (2019-05-25)
+        expected_result = """*1.0.2 (2019-05-25)*
 
-* Features *
-**Scope 1:**
-   - Add a new feature ([short_hash](/long_hash))
-   - Add another feature ([short_hash](/long_hash))
-**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
+*Features*
+*Scope 1:*
+   - Add a new feature (</long_hash|short_hash>)
+   - Add another feature (</long_hash|short_hash>)
+*Scope 2:* Add one more feature (</long_hash|short_hash>)"""
 
         result = execute_lane_test(group_by_scope: true, format: 'slack')
 

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -307,12 +307,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
 
       it "should hide in markdown format" do
         expected_result = """### Bug fixes
-        - Scope 1:
-           - Add a new feature([short_hash](/long_hash))
-           - Add another feature([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more([short_hash](/long_hash))
-        """
+- Scope 1:
+   - Add a new feature([short_hash](/long_hash))
+   - Add another feature([short_hash](/long_hash))
+- Scope 1: Add one more([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true)
 
@@ -321,12 +319,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
 
       it "should hide in plain format" do
         expected_result = """Bug fixes
-        - Scope 1:
-           - Add a new feature ([short_hash](/long_hash))
-           - Add another feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more ([short_hash](/long_hash))
-        """
+- Scope 1:
+   - Add a new feature ([short_hash](/long_hash))
+   - Add another feature ([short_hash](/long_hash))
+- Scope 1: Add one more ([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -335,70 +331,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
 
       it "should hide in slack format" do
         expected_result = """* Bug fixes *
-        - Scope 1:
-           - Add a new feature ([short_hash](/long_hash))
-           - Add another feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more ([short_hash](/long_hash))
-        """
-
-        result = execute_lane_test(group_by_scope: true, format: 'slack')
-
-        expect(result).to eq(expected_result)
-      end
-    end
-
-    describe 'dont group messages if group_by_scope is false' do
-      before do
-        commits = [
-          commit('feat', 'Scope 1', 'Add a new feature'),
-          commit('feat', 'Scope 1', 'Add another feature'),
-          commit('feat', 'Scope 2', 'Add one more feature')
-        ]
-
-        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-      end
-
-      it "should hide in markdown format" do
-        expected_result = """### Bug fixes
-        - Scope 1:
-           - Add a new feature([short_hash](/long_hash))
-        - Scope 1:
-           - Add another feature([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more([short_hash](/long_hash))
-        """
-
-        result = execute_lane_test(group_by_scope: true)
-
-        expect(result).to eq(expected_result)
-      end
-
-      it "should hide in plain format" do
-        expected_result = """Bug fixes
-        - Scope 1:
-           - Add a new feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add another feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more ([short_hash](/long_hash))
-        """
-
-        result = execute_lane_test(group_by_scope: true, format: 'plain')
-
-        expect(result).to eq(expected_result)
-      end
-
-      it "should hide in slack format" do
-        expected_result = """* Bug fixes *
-        - Scope 1:
-           - Add a new feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add another feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more ([short_hash](/long_hash))
-        """
+- Scope 1:
+   - Add a new feature ([short_hash](/long_hash))
+   - Add another feature ([short_hash](/long_hash))
+- Scope 1: Add one more ([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true, format: 'slack')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,11 @@ require 'fastlane' # to import the Action super class
 require 'fastlane/plugin/semantic_release' # import the actual plugin
 
 Fastlane.load_actions # load other actions (in case your plugin calls other actions or shared values)
+
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.max_formatted_output_length = 1000
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ Fastlane.load_actions # load other actions (in case your plugin calls other acti
 
 
 RSpec.configure do |config|
-  config.expect_with :rspec do |expectations|
+  config.expect_with(:rspec) do |expectations|
     expectations.max_formatted_output_length = 1000
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,6 @@ require 'fastlane/plugin/semantic_release' # import the actual plugin
 
 Fastlane.load_actions # load other actions (in case your plugin calls other actions or shared values)
 
-
 RSpec.configure do |config|
   config.expect_with(:rspec) do |expectations|
     expectations.max_formatted_output_length = 1000


### PR DESCRIPTION
> By I deleted the original repo error I closed this PR because :
> - https://github.com/xotahal/fastlane-plugin-semantic_release/pull/37

Allow to group commits by scope

Fix: 
- https://github.com/xotahal/fastlane-plugin-semantic_release/issues/35

Done:
- [x] Use Case: when all commits have scopes
- [x] Use Case: some commits don't have scopes
- [x] Fix `Other work is indentated inside Other work`
- [ ] Use Case: Breaking Change
- [x] Fix rubocop offenses

# Current

```
# Current
- **User Login:** add User Income Form Components 
- **Map:** search without country/state filters to open map borders to other cities/countries
- **Map:** revert -> search without country/state filters to open map borders to other cities/countries
```
The preview:
- **User Login:** add User Income Form Components 
- **Map:** search without country/state filters to open map borders to other cities/countries
- **Map:** revert -> search without country/state filters to open map borders to other cities/countries


# Grouping
```yaml
# Expected
- **User Login:** add User Income Form Components 
- **Map:**
   - search without country/state filters to open map borders to other cities/countries
   - revert -> search without country/state filters to open map borders to other cities/countries
```

The preview:
- **User Login:** add User Income Form Components 
- **Map:**
   - search without country/state filters to open map borders to other cities/countries
   - revert -> search without country/state filters to open map borders to other cities/countries
